### PR TITLE
Add Sonar Cloud integration and coverage reporting

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,18 @@
+{
+  "all": true,
+  "reporter": ["lcov"],
+  "exclude": [
+    "**/.next",
+    "**/dist",
+    "**/types",
+    "**/coverage",
+    "packages/*/test{,s}/**",
+    "packages/eslint-config-junat.live",
+    "**/*.d.ts",
+    "test{,s}/**",
+    "test{,-*}.{js,cjs,mjs,ts,tsx,jsx}",
+    "**/*{.,-}test.{js,cjs,mjs,ts,tsx,jsx}",
+    "**/{vite,vitest,next,ecosystem,stitches}.config.{js,ts}",
+    "**/.{eslint,mocha}rc.{js,cjs}"
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,3 +61,16 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  reporting:
+    runs-on: ubuntu-latest
+    name: SonarCloud Scan
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,16 +59,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
-      - name: Test
-        run: pnpm test
+      - name: Test with coverage
+        run: pnpm coverage
 
-  reporting:
-    runs-on: ubuntu-latest
-    name: SonarCloud Scan
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
       - uses: pnpm/action-setup@v2.0.1
         with:
           version: 7.1.7
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "start": "turbo run start",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "coverage": "shx rm -rf coverage/* && c8 pnpm run test --force"
   },
   "devDependencies": {
     "@junat/prettier": "workspace:*",
+    "c8": "^7.11.2",
+    "shx": "^0.3.4",
     "turbo": "^1.2.14"
   },
   "prettier": "@junat/prettier",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,13 @@ importers:
   .:
     specifiers:
       '@junat/prettier': workspace:*
+      c8: ^7.11.2
+      shx: ^0.3.4
       turbo: ^1.2.14
     devDependencies:
       '@junat/prettier': link:packages/prettier-config-junat.live
+      c8: 7.11.3
+      shx: 0.3.4
       turbo: 1.2.16
 
   packages/cms:
@@ -12081,7 +12085,7 @@ packages:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
     engines: {node: '>= 0.10'}
     dependencies:
-      resolve: 1.22.0
+      resolve: 1.22.1
     dev: true
 
   /recrawl-sync/2.2.2:
@@ -12313,7 +12317,7 @@ packages:
     optional: true
 
   /require-directory/2.1.1:
-    resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -14614,7 +14618,7 @@ packages:
     dev: true
 
   /wrappy/1.0.2:
-    resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=}
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   /write-file-atomic/3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.organization=junat
+sonar.projectKey=junat.live
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=.
+
+sonar.links.homepage=https://junat.live
+sonar.links.ci=https://github.com/jqpe/junat.live/actions
+sonar.links.scm=https://github.com/jqpe/junat.live
+sonar.links.issue=https://github.com/jqpe/junat.live/issues

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,3 +8,5 @@ sonar.links.homepage=https://junat.live
 sonar.links.ci=https://github.com/jqpe/junat.live/actions
 sonar.links.scm=https://github.com/jqpe/junat.live
 sonar.links.issue=https://github.com/jqpe/junat.live/issues
+
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
Regressions to test pipeline:
-  since c8 relies on v8, the tests need to be run in order to calculate coverage. Thus tests can't be cached and the test pipeline will take longer to complete.