### PR TITLE
build: use pnpm 7.7.0 publish config directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
             turbo-${{ github.job }}-${{ github.ref_name }}-${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-        # This step is required so that packages that rely on `publishConfig.directory` work correctly.
-        # e.g. '@junat/digitraffic': link:../digitraffic/dist
-      - name: Build statically linked packages
-        run: pnpm --filter=@junat/digitraffic build
-
       - name: Lint
         run: pnpm lint
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   },
   "prettier": "@junat/prettier",
   "engines": {
-    "pnpm": ">=7.4",
+    "pnpm": ">=7.7",
     "node": ">=14"
   },
-  "packageManager": "pnpm@7.6.0",
+  "packageManager": "pnpm@7.7.0",
   "pnpm": {
     "overrides": {
       "glob-parent@<5.1.2": ">=5.1.2",

--- a/packages/digitraffic/package.json
+++ b/packages/digitraffic/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "shx rm -rf dist && tsc --build && pnpm copy",
-    "copy": "shx cp package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.scripts=undefined; this.prettier=undefined;\" && pnpm i -r",
+    "copy": "shx cp package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.scripts=undefined; this.prettier=undefined;\"",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "lint": "eslint ."

--- a/packages/digitraffic/package.json
+++ b/packages/digitraffic/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "shx rm -rf dist && tsc --build && pnpm copy",
-    "copy": "shx cp package.json README.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.scripts=undefined; this.prettier=undefined;\"",
+    "copy": "shx cp package.json README.md dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.scripts=undefined; this.prettier=undefined;\"",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "lint": "eslint ."

--- a/packages/digitraffic/package.json
+++ b/packages/digitraffic/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "shx rm -rf dist && tsc --build && pnpm copy",
-    "copy": "shx cp package.json README.md dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.scripts=undefined; this.prettier=undefined;\"",
+    "copy": "shx cp package.json README.md dist && json -I -f dist/package.json -e \"this.private=false; this.publishConfig=undefined; this.devDependencies=undefined; this.scripts=undefined; this.prettier=undefined;\"",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "lint": "eslint ."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,7 @@ importers:
       shx: 0.3.4
       typescript: 4.7.4
       vitest: 0.18.0_jxgbpuaxp573lj2qic5mnggmzu
+    publishDirectory: dist
 
   packages/digitraffic-mqtt:
     specifiers:


### PR DESCRIPTION
Previously pnpm didn't link packages depending on their `publishConfig.directory` value so this had to be a manual effort. 
As of [pnpm 7.7.0](https://github.com/pnpm/pnpm/releases/tag/v7.7.0) this is now supported by default.


