### PR TITLE
chore(renovate): fix typo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
   "major": {
-    "dependencyDashboard": true
+    "dependencyDashboardApproval": true
   },
   "prCreation": "status-success",
   "packageRules": [


### PR DESCRIPTION
Intended to use `dependencyDashboardApproval` (9cb2e4ac412bec047a6c23fa6c65437005c360cd)

[no ci]
