### PR TITLE
Link to latest train and disallow /train/*/* routes from being crawled

### DIFF
--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,9 @@
+User-agent: *
+Allow: /
+
+# Don't allow indexing of /train/<date>/<trainNumber>. /train/<trainNumber> is still allowed;
+# showing a stale train is not very useful for people landing from search engines.
+
+Disallow: /train/*/*
+Disallow: /juna/*/*
+Disallow: /tog/*/*

--- a/site/src/pages/[stationName].tsx
+++ b/site/src/pages/[stationName].tsx
@@ -170,6 +170,19 @@ export default function StationPage({
 
 StationPage.layout = Page
 
+const getTrainHref = (locale: Locale, date: string, trainNumber: number) => {
+  const departureDate = new Date(Date.parse(date))
+  const now = new Date()
+
+  // The Digitraffic service returns trains 24 hours into the future and thus there's no risk of
+  // mistakingly using 'latest' for a train a week from now.
+  if (departureDate.getDay() === now.getDay()) {
+    return `/${getTrainPath(locale)}/${trainNumber}`
+  }
+
+  return `/${getTrainPath(locale)}/${getCalendarDate(date)}/${trainNumber}`
+}
+
 function TimetableTrainAnchor({
   trainNumber,
   type,
@@ -183,12 +196,7 @@ function TimetableTrainAnchor({
   setTimetableRowId: (id: string) => void
 }) {
   return (
-    <Link
-      passHref
-      href={`/${getTrainPath(locale)}/${getCalendarDate(
-        departureDate
-      )}/${trainNumber}`}
-    >
+    <Link passHref href={getTrainHref(locale, departureDate, trainNumber)}>
       <a onClick={() => setTimetableRowId(timetableRowId)}>
         {commuterLineId || `${type}${trainNumber}`}
       </a>


### PR DESCRIPTION
Improve experience for users landing from Google or similar by only letting crawlers index /train/\<trainNumber> and not /train/\<date>/\<trainNumber>.

Including the date in crawled results leads to stale pages.

- chore: add robots.txt
- feat: link to latest train for today's trains
