### PR TITLE
fix: degraded performance introduced by #42

### DIFF
--- a/site/src/pages/train/[date]/[trainNumber].tsx
+++ b/site/src/pages/train/[date]/[trainNumber].tsx
@@ -47,10 +47,12 @@ export default function TrainPage({
     }
   )
 
-  const [train, error] = useLiveTrainSubscription({
+  const [t, error] = useLiveTrainSubscription({
     initialTrain,
     enabled: initialTrain !== undefined
   })
+
+  const train = t || initialTrain
 
   const router = useRouter()
   const locale = getLocale(router.locale)


### PR DESCRIPTION
`useLiveTrainSubscription` will wait for the MQTT connection to be established, and as a consequence there would be an unnecesary delay before rendering anything.
