### PR TITLE
refactor: don't require timetable row links as props

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -4,6 +4,10 @@ import bundleAnalyzer from '@next/bundle-analyzer'
 const nextConfig = {
   reactStrictMode: true,
   distDir: process.env.CI === 'true' ? 'tmp' : '.next',
+  experimental: {
+    // https://github.com/vercel/next.js/pull/36436
+    newNextLinkBehavior: true
+  },
   i18n: {
     locales: ['fi', 'sv', 'en'],
     defaultLocale: 'fi',

--- a/site/src/components/Timetable.tsx
+++ b/site/src/components/Timetable.tsx
@@ -20,10 +20,6 @@ export interface TimetableProps {
   trains: TimetableRowTrain[]
   locale: 'fi' | 'en' | 'sv'
   translation: TimetableTranslations
-
-  StationAnchor: TimetableRowProps['StationAnchor']
-  TrainAnchor: TimetableRowProps['TrainAnchor']
-
   lastStationId: TimetableRowProps['lastStationId']
 }
 
@@ -71,8 +67,6 @@ export function Timetable({
   trains,
   translation,
   locale,
-  TrainAnchor,
-  StationAnchor,
   ...id
 }: TimetableProps) {
   if (trains.length === 0) {
@@ -94,8 +88,6 @@ export function Timetable({
           return (
             <TimetableRow
               cancelledText={translation.cancelledText}
-              StationAnchor={StationAnchor}
-              TrainAnchor={TrainAnchor}
               lastStationId={id.lastStationId}
               locale={locale}
               train={train}

--- a/site/src/components/TimetableRow.tsx
+++ b/site/src/components/TimetableRow.tsx
@@ -203,7 +203,7 @@ export function TimetableRow({
           href={getStationPath(train.destination[locale])}
           onClick={() => setTimetableRowId(timetableRowId)}
         >
-          train.destination[locale]
+          {train.destination[locale]}
         </Link>
       </StyledTimetableRowData>
 


### PR DESCRIPTION
Move `TimetableRow` links directly to component and don't require them as props. Previously they were passed as props, because the component was imported from an external library.  

Enables [experimental link behavior](https://github.com/vercel/next.js/pull/36436).