### PR TITLE
ci: fix publish diretory packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         run: pnpm install
 
       - name: Build packages
-        run: pnpm build --filter=\!site
+        run: pnpm build --filter=\!site && pnpm i
 
       - name: Lint
         run: pnpm lint


### PR DESCRIPTION
When `pnpm i` is first executed the dist directory doesn't exist and pnpm assumes the package doesn't either.

After receiving remote cache the dist directory _is_ there and a manual refresher is required. In cases where Turbo hasn't cached these packages the `build` script gets run which handles updating to pnpm.