### PR TITLE
ci: add check-types job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Check types
+        if: matrix.node-version == '18.x'
+        run: pnpm check-types
+
       - name: Test with coverage
         run: pnpm coverage
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
+    "check-types": "turbo run check-types",
     "start": "turbo run start",
     "test": "turbo run test",
     "coverage": "shx rm -rf coverage/* && c8 pnpm run --filter=./packages/* --filter=site test"

--- a/packages/digitraffic-mqtt/tsconfig.json
+++ b/packages/digitraffic-mqtt/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "skipLibCheck": true,
+    "incremental": true,
     "strict": true,
     "target": "es2020"
   },

--- a/packages/digitraffic/package.json
+++ b/packages/digitraffic/package.json
@@ -20,6 +20,7 @@
     "build": "shx rm -rf dist && tsc --build && pnpm copy",
     "copy": "shx cp package.json README.md dist && json -I -f dist/package.json -e \"this.private=false; this.publishConfig=undefined; this.devDependencies=undefined; this.scripts=undefined; this.prettier=undefined;\"  && pnpm i",
     "test": "vitest run",
+    "check-types": "tsc --noEmit",
     "coverage": "vitest run --coverage",
     "lint": "eslint ."
   },

--- a/packages/digitraffic/tsconfig.json
+++ b/packages/digitraffic/tsconfig.json
@@ -6,6 +6,7 @@
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "stripInternal": true,
+    "incremental": true,
     "module": "ESNext",
     "moduleResolution": "Node16",
     "outDir": "dist",

--- a/site/package.json
+++ b/site/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "analyze": "ANALYZE=true next build",
     "dev": "next dev",
+    "check-types": "tsc --noEmit",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/site/src/utils/sort_simplified_trains.ts
+++ b/site/src/utils/sort_simplified_trains.ts
@@ -4,7 +4,7 @@ export interface ITrain extends Partial<SimplifiedTrain> {
   scheduledTime: string
 }
 
-export const sortSimplifiedTrains = (trains: Readonly<ITrain[]>) => {
+export const sortSimplifiedTrains = <T extends ITrain>(trains: Readonly<T[]>) => {
   return [...trains].sort((aTrain, bTrain) => {
     return Date.parse(aTrain.scheduledTime) - Date.parse(bTrain.scheduledTime)
   })

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://turborepo.org/schema.json",
-  "baseBranch": "origin/main",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
@@ -12,6 +11,10 @@
     },
     "lint": {
       "outputs": []
+    },
+    "check-types": {
+      "dependsOn": ["^build"],
+      "outputs": ["**tsconfig.tsbuildinfo"]
     },
     "dev": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Check that types work so that deploying is not attempted. Previously the deployment was cancelled in CD if the server couldn't be started, usually because tsc would fail.
