### PR TITLE
feat: digitraffic error handling

### DIFF
--- a/site/.eslintrc.json
+++ b/site/.eslintrc.json
@@ -7,6 +7,7 @@
     "browser": true
   },
   "rules": {
-    "no-restricted-imports": ["error", "src/features/*"]
+    "no-restricted-imports": ["error", "src/features/*"],
+    "unicorn/no-null": "off"
   }
 }

--- a/site/src/components/DigitrafficError.tsx
+++ b/site/src/components/DigitrafficError.tsx
@@ -1,0 +1,152 @@
+import type { UseQueryResult } from '@tanstack/react-query'
+import type { SimplifiedTrain } from '@typings/simplified_train'
+import type { DigitrafficError as ErrorType } from '@junat/digitraffic/base/classes/digitraffic_error'
+
+import { styled } from '@config/theme'
+import { keyframes } from '@stitches/react'
+import React, { ReactNode } from 'react'
+import translate from '@utils/translate'
+import { Locale } from '@typings/common'
+
+const COUNTER = 'digitraffic-error-resolution-steps' as const
+
+const fadeIn = keyframes({
+  '0%': { opacity: 0, transform: 'scale(0.9)' },
+  '100%': { opacity: 1, transform: 'scale(1)' }
+})
+
+const focus = keyframes({
+  '0%': { outlineOffset: '0px' },
+  '100%': { outlineOffset: '3px' }
+})
+
+const Section = styled('section', {
+  '@media (prefers-reduced-motion: no-preference)': {
+    animation: `${fadeIn} 500ms`
+  },
+  background: '$primary200',
+  '@dark': {
+    background: '$primaryA200',
+    border: "1px solid $primary500"
+  },
+  padding: '$2',
+  borderRadius: '3px',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'start',
+  alignItems: 'start',
+  gap: '$2'
+})
+
+const List = styled('ul', {
+  counterReset: COUNTER,
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '$2'
+})
+
+const StyledDetails = (props: {
+  children: ReactNode | ReactNode[]
+  locale: Locale
+}) => {
+  const [open, setOpen] = React.useState(false)
+  const t = translate(props.locale)
+
+  const Details = styled('details', {
+    width: '100%',
+    marginLeft: '$1',
+    userSelect: 'none'
+  })
+
+  return (
+    <Details open={open} onClick={() => setOpen(!open)}>
+      <Summary css={{ '&::marker': { content: open ? '▾' : '▸' } }}>
+        {t('errors', 'show')}
+      </Summary>
+      {props.children}
+    </Details>
+  )
+}
+
+const Pre = styled('pre', {
+  fontFamily: 'monospace'
+})
+
+const Summary = styled('summary', {
+  '&::marker': { content: '▸', fontSize: '24px' },
+  '&:focus': {
+    outline: '1px solid $secondary600',
+    '@media (prefers-reduced-motion: no-preference)': {
+      animation: `${focus} 500ms forwards`
+    }
+  }
+})
+
+const ListItem = styled('li', {
+  '&::before': {
+    display: 'flex',
+    marginBottom: '$1',
+    alignItems: 'center',
+    justifyContent: 'center',
+    counterIncrement: COUNTER,
+    content: `counter(${COUNTER})`,
+    padding: '$1',
+    fontSize: '$mobile-caption',
+    background: '$slateGray800',
+    color: '$slateGray200',
+    borderRadius: '9999px',
+    maxWidth: '1rem',
+    maxHeight: '1rem'
+  }
+})
+
+const Button = styled('button', {
+  background: '$primary900',
+  color: '$primary100',
+  padding: '$1 $3',
+  borderRadius: '9999px',
+  '&:hover': {
+    cursor: 'pointer'
+  }
+})
+
+export function DigitrafficError(
+  props: UseQueryResult<SimplifiedTrain[], ErrorType> & { locale: Locale }
+) {
+  const t = translate(props.locale)
+
+  if (props.failureCount > 0 && !props.isError) {
+    return <p>{t('errors', 'digitraffic', 'refetching')}</p>
+  }
+
+  if (props.isError) {
+    return (
+      <Section>
+        <p>
+          {t('errors', 'digitraffic', 'requestError')}: {props.error.statusText}
+        </p>
+        {Boolean(props.error.body) && (
+          <StyledDetails locale={props.locale}>
+            <Pre>{props.error.body}</Pre>
+          </StyledDetails>
+        )}
+        <h2>{t('errors', 'digitraffic', 'whatToDo')}</h2>
+        <List>
+          <ListItem>
+            {t('errors', 'digitraffic', 'errorOrigin')}{' '}
+            <a href="https://status.digitraffic.fi/">status.digitraffic.fi</a>
+          </ListItem>
+          <ListItem>{t('errors', 'digitraffic', 'waitOrRetry')}</ListItem>
+          <ListItem>
+            {t('errors', 'digitraffic', 'lastStraw')}{' '}
+            <a href="https://vr.fi">vr.fi</a> {t('or')}{' '}
+            <a href="https://hsl.fi">hsl.fi</a>.
+          </ListItem>
+        </List>
+        <Button onClick={() => props.refetch()}>{t('tryAgain')}</Button>
+      </Section>
+    )
+  }
+  return null
+}

--- a/site/src/hooks/use_live_trains.ts
+++ b/site/src/hooks/use_live_trains.ts
@@ -1,4 +1,6 @@
 import type { GetTrainsOptions } from '@junat/digitraffic'
+import type { DigitrafficError } from '@junat/digitraffic/base/classes/digitraffic_error'
+import type { SimplifiedTrain } from '@typings/simplified_train'
 
 import { useQuery } from '@tanstack/react-query'
 import { fetchLiveTrains } from '@junat/digitraffic'
@@ -45,8 +47,12 @@ export const useLiveTrains = (opts: UseLiveTrainsOpts) => {
     })
   }
 
-  return useQuery([`trains/${opts.path}`, opts.count], queryFn, {
-    enabled: opts.localizedStations.length > 0,
-    keepPreviousData: true
-  })
+  return useQuery<SimplifiedTrain[], DigitrafficError>(
+    [`trains/${opts.path}`, opts.count],
+    queryFn,
+    {
+      enabled: opts.localizedStations.length > 0,
+      keepPreviousData: true
+    }
+  )
 }

--- a/site/src/locales/en.json
+++ b/site/src/locales/en.json
@@ -9,6 +9,8 @@
   "departureTime": "Departure time",
   "track": "Track",
   "loading": "Loading...",
+  "or": "or",
+  "tryAgain": "Try again",
 
   "stationPage": {
     "meta": {
@@ -37,7 +39,16 @@
     "positionUnavailable": "Location couldn't be fetched because location is unavailable.",
     "positionTimeout": "The location could not be retrieved. Request timed out.",
     "badGeolocationAccuracy": "Geolocation was inaccurate, the list of stations has been updated.",
-    "nojs": "Enable JavaScript in your browser settings."
+    "nojs": "Enable JavaScript in your browser settings.",
+    "show": "Show error message",
+    "digitraffic": {
+      "refetching": "Request failed, trying again...",
+      "requestError": "That did not work",
+      "whatToDo": "What can you do?",
+      "errorOrigin": "This is a problem with an external service provider, see it's status here:",
+      "waitOrRetry": "Wait a moment and retry by clicking the button below.",
+      "lastStraw": "If nothing is working, try"
+    }
   },
 
   "trainTypes": {

--- a/site/src/locales/fi.json
+++ b/site/src/locales/fi.json
@@ -9,6 +9,8 @@
   "departureTime": "Lähtöaika",
   "track": "Raide",
   "loading": "Ladataan...",
+  "or": "tai",
+  "tryAgain": "Kokeile uudelleen",
 
   "trafficDataSource": "Liikennetietojen lähde",
   "license": "lisenssi",
@@ -37,7 +39,16 @@
     "positionUnavailable": "Sijaintia ei voitu hakea, sijainninpaikannus ei ole saatavilla.",
     "positionTimeout": "Sijaintia ei voitu hakea. Paikantamisessa kesti liian kauan.",
     "badGeolocationAccuracy": "Sijainnin tarkkuus oli epäluotettava, lista on päivitetty.",
-    "nojs": "Laita JavaScript päälle selaimesi asetuksista."
+    "nojs": "Laita JavaScript päälle selaimesi asetuksista.",
+    "show": "Näytä virhe",
+    "digitraffic": {
+      "refetching": "Pyyntö epäonnistui, yritetään uudelleen...",
+      "requestError": "Ei toiminut",
+      "whatToDo": "Mitä voit tehdä?",
+      "errorOrigin": "Ongelma on Fintrafficin puolella, katso rajapinnan tila täältä:",
+      "waitOrRetry": "Odota hetki ja yritä pyyntöä uudelleen alla olevasta napista.",
+      "lastStraw": "Jos vieläkään ei toimi, kokeile"
+    }
   },
 
   "trainTypes": {

--- a/site/src/locales/sv.json
+++ b/site/src/locales/sv.json
@@ -12,6 +12,8 @@
 
   "trafficDataSource": "Trafikdatakälla",
   "license": "licens",
+  "or": "eller",
+  "tryAgain": "Försök igen",
 
   "stationPage": {
     "meta": {
@@ -37,7 +39,16 @@
     "positionUnavailable": "Platsen kunde inte hämtas.",
     "positionTimeout": "Platsen kunde inte hämtas. Begäran tog för lång tid.",
     "badGeolocationAccuracy": "Geolokaliseringen var felaktig, listan har uppdaterats med stationer nära dig.",
-    "nojs": "Aktivera JavaScript i din webbläsarinställningar."
+    "nojs": "Aktivera JavaScript i din webbläsarinställningar.",
+    "show": "Visa felmeddelande",
+    "digitraffic": {
+      "refetching": "Begäran misslyckades, försöker igen...",
+      "requestError": "Det fungerade inte",
+      "whatToDo": "Vad kan du göra?",
+      "errorOrigin": "Det här är ett problem med en extern tjänsteleverantör, se dess status här:",
+      "waitOrRetry": "Vänta ett ögonblick och försök igen genom att klicka på knappen nedan.",
+      "lastStraw": "Om ingenting fungerar, försök"
+    }
   },
 
   "trainTypes": {

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -23,7 +23,9 @@ interface AppProviderProps {
 }
 
 const AppProvider = ({ children }: AppProviderProps) => {
-  const queryClient = new QueryClient()
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: 1 } }
+  })
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
Show an error state if Digitraffic is down.

- chore: disable no-null lint
- chore: add error type
- feat(i18n): add digitraffic error states
- feat: only retry queries once
- feat: add digitraffic error component
- feat: display fetch error to user
