### PR TITLE
refactor: remove subdomains from caching strat

### DIFF
--- a/site/tools/sw/runtime_caching.js
+++ b/site/tools/sw/runtime_caching.js
@@ -101,7 +101,7 @@ const runtimeCaching = [
   // API routes
   {
     urlPattern: ({ url }) => {
-      const ORIGIN_REGEX = /https:\/\/(?:en|sv|fi)?\.?junat\.live/
+      const ORIGIN_REGEX = /^https:\/\/junat\.live$/
 
       const isSameOrigin = ORIGIN_REGEX.test(url.origin)
       if (!isSameOrigin) return false
@@ -123,7 +123,7 @@ const runtimeCaching = [
   // All other requests from the same origin
   {
     urlPattern: ({ url }) => {
-      const ORIGIN_REGEX = /https:\/\/(?:en|sv|fi)?\.?junat\.live/
+      const ORIGIN_REGEX = /^https:\/\/junat\.live$/
 
       const isSameOrigin = ORIGIN_REGEX.test(url.origin)
       if (!isSameOrigin) return false


### PR DESCRIPTION
Subdomains are no longer used as they caused issues with caching (same origin policy; subdomains are considered separate origins)