### PR TITLE
feat: disable user select

### DIFF
--- a/site/src/components/Select.tsx
+++ b/site/src/components/Select.tsx
@@ -40,6 +40,7 @@ const StyledContent = styled(Primitive.Content, {
 const StyledItem = styled(Primitive.Item, {
   display: 'flex',
   alignItems: 'center',
+  userSelect: 'none',
   padding: '0px 10px',
   borderRadius: '9999px',
   transition: 'background-color 0.2s sine-in',


### PR DESCRIPTION
The select component items needn't be selected by the user. Further, on mobile devices selection can result in a degraded UX.
