### PR TITLE
fix: hide button if api returned empty array

### DIFF
--- a/site/src/pages/[stationName].tsx
+++ b/site/src/pages/[stationName].tsx
@@ -222,7 +222,7 @@ export const getStaticProps = async (
  * The case: `191 % 100 != 0`
  */
 function showFetchButton(trains?: unknown[]) {
-  if (!trains) {
+  if (!trains || trains.length === 0) {
     return false
   }
 


### PR DESCRIPTION
Digitraffic returns an empty array with HTTP 200 which was not covered.