### PR TITLE
fix: next_locale cookie

### DIFF
--- a/site/src/components/input/language_select/helpers.tsx
+++ b/site/src/components/input/language_select/helpers.tsx
@@ -48,7 +48,8 @@ export const handleValueChange: OnValueChange = ({ router, value }) => {
   }
 
   Cookies.set('NEXT_LOCALE', value, {
-    sameSite: 'strict',
+    sameSite: 'Lax',
+    secure: true,
     expires: 365
   })
 


### PR DESCRIPTION
Using `sameSite: 'strict'` resulted in unintended behavior where locale preference was not persisted across sessions.