### PR TITLE
feat: dynamically import toast inside app

### DIFF
--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -8,9 +8,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 import constants from 'src/constants'
 
+import dynamic from 'next/dynamic'
+
 import { getLocale } from '@utils/get_locale'
 import { useWakeLock } from '@hooks/use_wake_lock'
-import { ToastProvider } from '@features/toast'
+
+const ToastProvider = dynamic(() =>
+  import('@features/toast').then(mod => mod.ToastProvider)
+)
+const Toast = dynamic(() => import('@features/toast').then(mod => mod.Toast))
 
 interface AppProps extends NextAppProps {
   Component: NextAppProps['Component'] & {
@@ -29,7 +35,10 @@ const AppProvider = ({ children }: AppProviderProps) => {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ToastProvider>{children}</ToastProvider>
+      <ToastProvider>
+        {children}
+        <Toast />
+      </ToastProvider>
     </QueryClientProvider>
   )
 }

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import type { GeolocationButtonProps } from '@features/geolocation'
-import type { ToastProps } from '@features/toast'
 import type { GetStaticPropsResult } from 'next'
 import type { LocalizedStation } from '@lib/digitraffic'
 
@@ -23,9 +22,6 @@ import translate from '@utils/translate'
 import i from '@utils/interpolate_string'
 import { getStations } from '@utils/get_stations'
 
-const Toast = dynamic<ToastProps>(() =>
-  import('@features/toast').then(mod => mod.Toast)
-)
 const GeolocationButton = dynamic<GeolocationButtonProps>(() =>
   import('@features/geolocation').then(mod => mod.GeolocationButton)
 )
@@ -76,7 +72,6 @@ export default function HomePage({ initialStations }: Props) {
           locale={locale}
         />
       </main>
-      <Toast />
     </>
   )
 }


### PR DESCRIPTION
Move Toast component to app instead of importing it on each page separately. This makes the `useToast` hook more preditable.