### PR TITLE
fix: don't require station shortcode to switch locale

### DIFF
--- a/site/src/components/input/language_select/index.tsx
+++ b/site/src/components/input/language_select/index.tsx
@@ -24,10 +24,6 @@ export function LanguageSelect({ router }: { router: NextRouter }) {
       defaultValue={router.locale}
       label={translate(locale)('changeLanguage')}
       onValueChange={value => {
-        if (!currentShortCode) {
-          throw new TypeError('Expected currentShortCode to be defined.')
-        }
-
         handleValueChange({ currentShortCode, router, stations, value })
       }}
     />


### PR DESCRIPTION
Requiring current short code to be defined broke switching locale for home- and train pages.