### PR TITLE
refactor: remove noscript spaghetti 

### DIFF
--- a/packages/design-system/src/styles/global.ts
+++ b/packages/design-system/src/styles/global.ts
@@ -59,20 +59,5 @@ export const global = globalCss({
     a: {
       color: '$slateGray200'
     }
-  },
-
-  ...Object.fromEntries(
-    [
-      ['fi', 'en', 'sv'],
-      ['en', 'fi', 'sv'],
-      ['sv', 'en', 'fi']
-    ].map(keys => [
-      `:root:lang(${keys[0]}) .noscript-alert`,
-      {
-        [`p[lang="${keys[1]}"], p[lang="${keys[2]}"]`]: {
-          display: 'none'
-        }
-      }
-    ])
-  )
+  }
 })

--- a/site/src/components/common/no_script/index.tsx
+++ b/site/src/components/common/no_script/index.tsx
@@ -1,27 +1,11 @@
-import type { CSS } from '@stitches/react'
-import type { Locale } from '@typings/common'
+import type { PropsWithChildren } from 'react'
 
 import { StyledNoScript } from './styles'
 
-export function NoScript({
-  css,
-  as,
-  translations
-}: {
-  translations: Record<Locale, string>
-  css?: CSS
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  as?: React.ComponentType<any> | string
-}) {
+export function NoScript(props: PropsWithChildren) {
   return (
-    <StyledNoScript css={css} as={as} className="noscript-alert">
-      {Object.keys(translations).map(key => {
-        return (
-          <p lang={key} key={key}>
-            {translations[key as Locale]}
-          </p>
-        )
-      })}
+    <StyledNoScript>
+      <p>{props.children}</p>
     </StyledNoScript>
   )
 }

--- a/site/src/components/common/no_script/styles.tsx
+++ b/site/src/components/common/no_script/styles.tsx
@@ -11,5 +11,10 @@ export const StyledNoScript = styled('noscript', {
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
-  flexDirection: 'column'
+  flexDirection: 'column',
+
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  left: 0
 })

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -12,11 +12,13 @@ import dynamic from 'next/dynamic'
 
 import { getLocale } from '@utils/get_locale'
 import { useWakeLock } from '@hooks/use_wake_lock'
+import translate from '@utils/translate'
 
 const ToastProvider = dynamic(() =>
   import('@features/toast').then(mod => mod.ToastProvider)
 )
 const Toast = dynamic(() => import('@features/toast').then(mod => mod.Toast))
+const NoScript = dynamic(() => import('@components/common/no_script'))
 
 interface AppProps extends NextAppProps {
   Component: NextAppProps['Component'] & {
@@ -56,6 +58,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     return (
       <AppProvider>
         <Component.layout layoutProps={layoutProps}>
+          <NoScript>
+            {translate(getLocale(router.locale))('errors', 'nojs')}
+          </NoScript>
+
           <Component {...pageProps} />
         </Component.layout>
       </AppProvider>
@@ -64,6 +70,10 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <AppProvider>
+      <NoScript>
+        {translate(getLocale(router.locale))('errors', 'nojs')}
+      </NoScript>
+
       <Component {...pageProps} />
     </AppProvider>
   )

--- a/site/src/pages/_document.tsx
+++ b/site/src/pages/_document.tsx
@@ -3,10 +3,7 @@ import { Html, Head, Main, NextScript } from 'next/document'
 import constants from 'src/constants'
 
 import { getCssText } from '@junat/design'
-import { NoScript } from '@components/common/no_script'
 import * as styles from '@junat/design/dist/styles'
-
-import translation from '@utils/translate'
 
 export default function Document() {
   styles.reset()
@@ -53,7 +50,6 @@ export default function Document() {
         />
       </Head>
       <body>
-        <NoScript translations={translation('all')('errors', 'nojs')} />
         <Main />
         <NextScript />
       </body>


### PR DESCRIPTION
- Removes `.noscript-alert` global styles
- Use Next.js router for translations, remove hardcoded values
- Simplify component and remove unused properties
- Fix noscript alert to top of the page