### PR TITLE
ci: use tag for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,7 @@ name: Test and deploy
 
 on:
   push:
-    paths-ignore:
-      - '**README.md'
-      - 'docs/**'
-    branches: [main]
+    tags: ['r[0-9]+']
 
 jobs:
   test:
@@ -45,7 +42,7 @@ jobs:
           context: .
           file: ./site/Dockerfile
           push: true
-          tags: nykanen/junat:latest,nykanen/junat:${{ github.sha }}
+          tags: nykanen/junat:latest,nykanen/junat:${{ github.ref }}
           platforms: linux/amd64,linux/arm64
 
   deploy:
@@ -66,7 +63,7 @@ jobs:
           terraform_version: 1.3.6
 
       - run: terraform init
-      - run: terraform plan -var 'image_version=${{ github.sha }}'
+      - run: terraform plan -var 'image_version=${{ github.ref }}'
       - run: terraform apply -auto-approve -input=false
 
   purge-cache:


### PR DESCRIPTION
Junat.live uses trunk based development, and the increased build times due to Dockerizing the deployment make this difficult. From now on, new releases have to be explicitly requested. This does come with the added benefit of releases being documented and less frequent. 