### PR TITLE
fix: generate pages for all stations, tweak geolocation stations

### DIFF
--- a/site/src/features/geolocation/hooks/use_geolocation.ts
+++ b/site/src/features/geolocation/hooks/use_geolocation.ts
@@ -59,7 +59,7 @@ export const useGeolocation = ({
 }: UseGeolocationProps) => {
   const t = translate(locale)
 
-  const { data: stations } = useStations()
+  const { data: stations } = useStations({ keepNonPassenger: false })
   const router = useRouter()
   const toast = useToast(state => state.toast)
 
@@ -108,7 +108,7 @@ export function handlePosition<
   toast: (title: string) => unknown
   router: { push: (route: string) => unknown }
 }) {
-  if (typeof stations === 'undefined') {
+  if (stations === undefined) {
     return
   }
 

--- a/site/src/hooks/use_stations.ts
+++ b/site/src/hooks/use_stations.ts
@@ -1,4 +1,5 @@
 import type { LocalizedStation } from '@lib/digitraffic'
+import type { GetStationsOptions } from '@junat/digitraffic'
 
 import { fetchStations } from '@junat/digitraffic'
 import { useQuery } from '@tanstack/react-query'
@@ -7,18 +8,19 @@ import translate from '@utils/translate'
 
 import { INACTIVE_STATIONS } from 'src/constants'
 
-const getStations = async () => {
+const getStations = async (opts?: GetStationsOptions) => {
   return fetchStations({
     inactiveStations: INACTIVE_STATIONS,
     betterNames: true,
     i18n: translate('all')('stations'),
     proxy: true,
-    keepNonPassenger: true
+    keepNonPassenger: true,
+    ...opts
   })
 }
 
-export const useStations = () => {
-  return useQuery<LocalizedStation[]>(['stations '], getStations, {
+export const useStations = (opts?: GetStationsOptions) => {
+  return useQuery<LocalizedStation[]>(['stations '], () => getStations(opts), {
     cacheTime: Infinity
   })
 }

--- a/site/src/pages/[stationName].tsx
+++ b/site/src/pages/[stationName].tsx
@@ -171,7 +171,9 @@ export const getStaticPaths = async (
 
   for (const locale of context.locales) {
     const stations = await getStations({
-      betterNames: true
+      betterNames: true,
+      keepInactive: true,
+      keepNonPassenger: true
     })
 
     paths = [
@@ -201,7 +203,9 @@ export const getStaticProps = async (
     return { notFound: true }
   }
   const stations = await getStations({
-    betterNames: true
+    betterNames: true,
+    keepInactive: true,
+    keepNonPassenger: true
   })
 
   const station = stations.find(


### PR DESCRIPTION
As these stations are now visible in the UI after #132, also create pages for them. As a tradeoff build times will increase.

This pull request also fixes an issue where clicking geolocation button would populate the list with inactive and non passenger stations. 