### PR TITLE
fix: require locale to be set for get formatted date

### DIFF
--- a/site/src/features/pages/single_train/components/page.tsx
+++ b/site/src/features/pages/single_train/components/page.tsx
@@ -71,7 +71,7 @@ export function TrainPage({ trainNumber, departureDate }: TrainPageProps) {
   const router = useRouter()
   const locale = getLocale(router.locale)
 
-  const formattedDate = getFormattedDate(departureDate)
+  const formattedDate = getFormattedDate(departureDate, locale)
 
   const t = translate(locale)
 

--- a/site/src/features/pages/single_train/helpers.ts
+++ b/site/src/features/pages/single_train/helpers.ts
@@ -1,13 +1,11 @@
-import { DEFAULT_LOCALE } from '~/constants'
-
 /**
  * Returns the calendar date according to locale.
  *
  * @param date {"latest" | string} Either latest or a date that can be parsed with `Date.parse`.
  * @param locale Locale to format the time with.
  */
-export const getFormattedDate = (date: string, locale?: string | string[]) => {
-  const dateTime = Intl.DateTimeFormat(locale || DEFAULT_LOCALE, {
+export const getFormattedDate = (date: string, locale: string | string[]) => {
+  const dateTime = Intl.DateTimeFormat(locale, {
     dateStyle: 'long'
   })
 

--- a/site/src/features/pages/single_train/tests/helpers.test.ts
+++ b/site/src/features/pages/single_train/tests/helpers.test.ts
@@ -5,7 +5,7 @@ import exp from 'constants'
 
 describe('get formatted date', () => {
   it("doesn't throw on an invalid time", () => {
-    expect(() => getFormattedDate('test')).not.toThrow()
+    expect(() => getFormattedDate('test', 'fi')).not.toThrow()
   })
 })
 


### PR DESCRIPTION
This function is used for localized dates and thus assuming locale with DEFAULT_LOCALE constant is invalid.
