### PR TITLE
fix: use network first to avoid empty responses

### DIFF
--- a/site/tools/sw/runtime_caching.js
+++ b/site/tools/sw/runtime_caching.js
@@ -66,7 +66,7 @@ const runtimeCaching = [
   // _next/data
   {
     urlPattern: /\/_next\/data\/[^\/]+\/.+\.json$/i,
-    handler: 'StaleWhileRevalidate',
+    handler: 'NetworkFirst',
     options: {
       cacheName: 'next-data',
       expiration: {


### PR DESCRIPTION
The service worker would sometimes serve a cached response with an empty object for `getServerSideProps`. This resulted in the train page failing to load as `trainNumber` and `departureDate` were undefined. 

Using NetworkFirst will improve reliability, but on the otherhand will also incur costs to the end user since runtime caching doesn't work for Next.js data. 

This should be treated as a hotfix rather than a complete solution. 