### PR TITLE
ci: use pnpm fetch to cache deps

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -25,10 +25,10 @@ COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=builder /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
 
-# Build the project
 COPY --from=builder /app/out/full/ .
-RUN pnpm install -r
+RUN pnpm fetch
 
+RUN pnpm install -r --offline
 
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN  \
     --mount=type=secret,id=SENTRY_DSN \  

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -10,22 +10,9 @@ RUN npm --global install pnpm
 RUN apk add --no-cache libc6-compat
 RUN apk update
 
-FROM base AS builder
-
-COPY . .
-RUN pnpm dlx turbo prune --scope=site --docker
-
-# Add lockfile and package.json's of isolated subworkspace
 FROM base AS installer
 
-# First install the dependencies (as they change less often)
-COPY .gitignore .gitignore
-COPY --from=builder /app/out/json/ .
-
-COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
-COPY --from=builder /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
-
-COPY --from=builder /app/out/full/ .
+COPY . .
 RUN pnpm fetch
 
 RUN pnpm install -r --offline


### PR DESCRIPTION
Leverages layer caching to skip fetching dependencies over the wire, potentially decreasing build times by a lot.

Blocked by https://togithub.com/vercel/turbo/issues/2798

## Disable turbo prune

As cited above, `turbo prune` doesn't work as intended. Since the application is more of a monolithic app than a monorepo, disabling it doesn't affect the build times as much as fetching the dependencies. If it has to be one or the other, not using `turbo prune` and instead copying the whole shebang is better suited for the build. 

## Improvements to build time

On my local machine leveraging pnpm fetch resulted in two minutes faster build (non cached vs cached), although it's likely that the improvement is more noticeable in CI if bandwidth is throttled.  The time it took to fetch dependencies was 87.2s 

```sh
nykanen@jape:~/Projects/junat.live$ docker buildx build -f site/Dockerfile --secret=id=SENTRY_AUTH_TOKEN,src=<(echo $TOKEN) .
[+] Building 162.2s (22/22) FINISHED                                                                                                                                                             
 => [internal] load build definition from Dockerfile                                                                                                                                        0.0s
 => => transferring dockerfile: 1.16kB                                                                                                                                                      0.0s
 => [internal] load .dockerignore                                                                                                                                                           0.0s
 => => transferring context: 34B                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/node:18-alpine                                                                                                                           2.2s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                 0.0s
 => [base 1/5] FROM docker.io/library/node:18-alpine@sha256:a136ed7b0df71082cdb171f36d640ea3b392a5c70401c642326acee767b8c540                                                                0.0s
 => [internal] load build context                                                                                                                                                           2.1s
 => => transferring context: 495.57MB                                                                                                                                                       2.0s
 => CACHED [base 2/5] WORKDIR /app                                                                                                                                                          0.0s
 => CACHED [base 3/5] RUN npm --global install pnpm                                                                                                                                         0.0s
 => CACHED [base 4/5] RUN apk add --no-cache libc6-compat                                                                                                                                   0.0s
 => CACHED [base 5/5] RUN apk update                                                                                                                                                        0.0s
 => CACHED [runner 1/7] RUN addgroup --system --gid 1001 nodejs                                                                                                                             0.0s
 => CACHED [runner 2/7] RUN adduser --system --uid 1001 nextjs                                                                                                                              0.0s
 => [installer 1/4] COPY . .                                                                                                                                                                6.0s
 => [installer 2/4] RUN pnpm fetch                                                                                                                                                         87.2s
 => [installer 3/4] RUN pnpm install -r --offline                                                                                                                                           2.0s
 => [installer 4/4] RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN      --mount=type=secret,id=SENTRY_DSN     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) &&     export   60.9s 
 => [runner 3/7] COPY --from=installer /app/site/next.config.js .                                                                                                                           0.0s 
 => [runner 4/7] COPY --from=installer /app/site/package.json .                                                                                                                             0.0s 
 => [runner 5/7] COPY --from=installer --chown=nextjs:nodejs /app/site/.next/standalone .                                                                                                   0.6s
 => [runner 6/7] COPY --from=installer --chown=nextjs:nodejs /app/site/.next/static ./site/.next/static                                                                                     0.1s
 => [runner 7/7] COPY --from=installer --chown=nextjs:nodejs /app/site/public ./site/public                                                                                                 0.0s
 => exporting to image                                                                                                                                                                      0.5s
 => => exporting layers                                                                                                                                                                     0.5s
 => => writing image sha256:fcfd682e6f26b3ff486575db37963586fd76276664f23b6e7507fa40809e5328                                                                                                0.0s
nykanen@jape:~/Projects/junat.live$ docker buildx build -f site/Dockerfile --secret=id=SENTRY_AUTH_TOKEN,src=<(echo $TOKEN) .
[+] Building 2.6s (22/22) FINISHED                                                                                                                                                               
 => [internal] load build definition from Dockerfile                                                                                                                                        0.0s
 => => transferring dockerfile: 32B                                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                                           0.0s
 => => transferring context: 34B                                                                                                                                                            0.0s
 => [internal] load metadata for docker.io/library/node:18-alpine                                                                                                                           2.2s
 => [auth] library/node:pull token for registry-1.docker.io                                                                                                                                 0.0s
 => [base 1/5] FROM docker.io/library/node:18-alpine@sha256:a136ed7b0df71082cdb171f36d640ea3b392a5c70401c642326acee767b8c540                                                                0.0s
 => [internal] load build context                                                                                                                                                           0.3s
 => => transferring context: 1.89MB                                                                                                                                                         0.3s
 => CACHED [base 2/5] WORKDIR /app                                                                                                                                                          0.0s
 => CACHED [base 3/5] RUN npm --global install pnpm                                                                                                                                         0.0s
 => CACHED [base 4/5] RUN apk add --no-cache libc6-compat                                                                                                                                   0.0s
 => CACHED [base 5/5] RUN apk update                                                                                                                                                        0.0s
 => CACHED [runner 1/7] RUN addgroup --system --gid 1001 nodejs                                                                                                                             0.0s
 => CACHED [runner 2/7] RUN adduser --system --uid 1001 nextjs                                                                                                                              0.0s
 => CACHED [installer 1/4] COPY . .                                                                                                                                                         0.0s
 => CACHED [installer 2/4] RUN pnpm fetch                                                                                                                                                   0.0s
 => CACHED [installer 3/4] RUN pnpm install -r --offline                                                                                                                                    0.0s
 => CACHED [installer 4/4] RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN      --mount=type=secret,id=SENTRY_DSN     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) &&     e  0.0s
 => CACHED [runner 3/7] COPY --from=installer /app/site/next.config.js .                                                                                                                    0.0s
 => CACHED [runner 4/7] COPY --from=installer /app/site/package.json .                                                                                                                      0.0s
 => CACHED [runner 5/7] COPY --from=installer --chown=nextjs:nodejs /app/site/.next/standalone .                                                                                            0.0s
 => CACHED [runner 6/7] COPY --from=installer --chown=nextjs:nodejs /app/site/.next/static ./site/.next/static                                                                              0.0s
 => CACHED [runner 7/7] COPY --from=installer --chown=nextjs:nodejs /app/site/public ./site/public                                                                                          0.0s
 => exporting to image                                                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                                                     0.0s
 => => writing image sha256:fcfd682e6f26b3ff486575db37963586fd76276664f23b6e7507fa40809e5328  
```


