### PR TITLE
fix: date picker bleeds focus

### DIFF
--- a/site/src/features/pages/single_train/components/date_picker.tsx
+++ b/site/src/features/pages/single_train/components/date_picker.tsx
@@ -13,7 +13,7 @@ import { PrimaryButton } from '~/components/buttons/primary'
 import translate from '~/utils/translate'
 import interpolateString from '~/utils/interpolate_string'
 
-import { getFormattedDate } from '../helpers'
+import { getFormattedDate, handleAutoFocus } from '../helpers'
 import { getCalendarDate } from '~/utils/date'
 
 const Dialog = dynamic(() =>
@@ -67,7 +67,7 @@ export function DatePicker(props: DatePickerProps) {
       <Dialog
         title={t('chooseDate')}
         description={t('changeDepartureDate')}
-        onOpenAutoFocus={event => event.preventDefault()}
+        onOpenAutoFocus={handleAutoFocus}
       >
         <Formik
           initialValues={{

--- a/site/src/features/pages/single_train/helpers.ts
+++ b/site/src/features/pages/single_train/helpers.ts
@@ -22,3 +22,21 @@ export const getFormattedDate = (
 
   return intl.format(parsedDate)
 }
+
+/**
+ * Workaround to not focus date input which triggers a modal dialog on some user agents, but keep the focus context inside dialog.
+ */
+export const handleAutoFocus = (event: Event) => {
+  type EventTargetWithFocus = EventTarget & { focus: () => unknown }
+
+  // don't focus the date input as this causes user agent date picker dialog to open
+  event.preventDefault()
+  // ...but keep the dialog focused so the focus doesn't "bleed"
+  if (
+    event.target &&
+    'focus' in event.target &&
+    typeof (event.target as EventTargetWithFocus).focus === 'function'
+  ) {
+    ;(event.target as EventTargetWithFocus).focus()
+  }
+}


### PR DESCRIPTION
Currently, opening the date picker dialog causes focus to bleed outside the dialog. On tab, instead of focusing the date input, language selector is focused instead. 

This fixes that by preventing the default (focusing date input) and instead focusing the dialog.