### PR TITLE
ci: pnpm fetch cache mount

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,12 +1,12 @@
 # Base is used for all steps and contains necessary dependencies
-FROM node:18-alpine AS base
+FROM node:v18.12.1-alpine AS base
 WORKDIR /app
 
 # Disable telemetry
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV DOCKER=true
 
-RUN npm --global install pnpm
+RUN npm --global install pnpm@7.21.0
 RUN apk add --no-cache libc6-compat
 RUN apk update
 

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -13,9 +13,9 @@ RUN apk update
 FROM base AS installer
 
 COPY . .
-RUN pnpm fetch
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store pnpm fetch | grep -v "cross-device link not permitted\|Falling back to copying packages from store"
 
-RUN pnpm install -r --offline
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store pnpm install -r --offline
 
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN  \
     --mount=type=secret,id=SENTRY_DSN \  


### PR DESCRIPTION
Fixes an issue where dependencies could not be found when running docker buildx in ci.