### PR TITLE
fix: make load more trains button text nonselectable

### DIFF
--- a/site/src/components/buttons/animated_background/styles.tsx
+++ b/site/src/components/buttons/animated_background/styles.tsx
@@ -21,6 +21,7 @@ export const StyledBackground = styled('div', {
 export const StyledButton = styled(motion.button, {
   overflow: 'hidden',
   position: 'relative',
+  userSelect: 'none',
   cursor: 'pointer',
   zIndex: 1,
   border: '1px solid $primary600',


### PR DESCRIPTION
Button text not being selectable is the default used by many web pages. Especially on mobile, selecting text is not what most people expect.
