### PR TITLE
ci: use current node.js version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 19.x]
 
     steps:
       - uses: actions/checkout@v3
@@ -58,14 +58,14 @@ jobs:
         run: pnpm lint
 
       - name: Check types
-        if: matrix.node-version == '18.x'
+        if: matrix.node-version == '19.x'
         run: pnpm check-types
 
       - name: Test with coverage
         run: pnpm coverage
 
       - name: SonarCloud Scan
-        if: matrix.node-version == '18.x'
+        if: matrix.node-version == '19.x'
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The repo consists of three main packages:
   ```
 
 ## Developing locally
-Node.js version 14 is required; 14, 16 and 18 are tested.
+Node.js version 14 is required; 14, 16 and 19 are tested.
 
 First, clone the repository with your preferred method. Whether that be the Github CLI, degit or just git commands.
 


### PR DESCRIPTION
Node.js version 19 is used for deployments so it makes sense to test against it. 