### PR TITLE
ci: add bash

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -7,7 +7,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV DOCKER=true
 
 RUN npm --global install pnpm@7.26.2
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat bash
 RUN apk update
 
 FROM base AS builder


### PR DESCRIPTION
Alpine doesn't come with bash installed. This resulted in the build command failing with the error message ` sh: ./copy.sh: not found`. The shebang `#!/bin/bash` in `copy.sh` was the cause of this issue as bash was not installed. 

Solution: install bash; we can't use sh as we are using bash's `read` which is different than the one provided by sh.
 