### PR TITLE
feat: use security headers

### DIFF
--- a/junat.live.nomad
+++ b/junat.live.nomad
@@ -28,12 +28,12 @@ job "junat" {
         provider = "nomad"
         tags = [
           "traefik.http.routers.http.rule=Host(`junat.live`)",
-
-          "traefik.http.middlewares.http.headers.frameDeny=true",
-          "traefik.http.middlewares.http.headers.contentTypeNosniff=true",
-          "traefik.http.middlewares.http.headers.accessControlAllowOriginList=*",
-          "traefik.http.middlewares.http.headers.referrerPolicy=strict-origin-when-cross-origin",
-          "traefik.http.middlewares.http.headers.contentSecurityPolicy=\"default-src 'self';object-src 'none';form-action 'self';script-src 'self';connect-src 'self' fonts.gstatic.com wss://rata.digitraffic.fi *.junat.live rata.digitraffic.fi;font-src fonts.gstatic.com;style-src 'self' 'unsafe-inline';img-src 'self';manifest-src 'self';prefetch-src 'self';\""
+          "traefik.http.middlewares.headers.headers.frameDeny=true",
+          "traefik.http.middlewares.headers.headers.contentTypeNosniff=true",
+          "traefik.http.middlewares.headers.headers.accessControlAllowOriginList=*",
+          "traefik.http.middlewares.headers.headers.referrerPolicy=strict-origin-when-cross-origin",
+          "traefik.http.middlewares.headers.headers.contentSecurityPolicy=\"default-src 'self';object-src 'none';form-action 'self';script-src 'self';connect-src 'self' fonts.gstatic.com wss://rata.digitraffic.fi *.junat.live rata.digitraffic.fi;font-src fonts.gstatic.com;style-src 'self' 'unsafe-inline';img-src 'self';manifest-src 'self';prefetch-src 'self';\"",
+          "traefik.http.routers.http.middlewares=headers"
         ]
       }
 


### PR DESCRIPTION
Although the middleware was defined, it was never used. Use it.
