### PR TITLE
fix: make primary button focus indicator visible

### DIFF
--- a/site/src/components/buttons/primary/styles.tsx
+++ b/site/src/components/buttons/primary/styles.tsx
@@ -13,7 +13,7 @@ export const StyledPrimaryButton = styled('button', {
   padding: '$xs $m',
   '&:focus': {
     outlineColor: 'transparent',
-    borderColor: '$slateGray700'
+    border: '2px solid $primary500'
   },
   '&:hover': {
     background: '$slateGray700'


### PR DESCRIPTION
On light mode the previous indication was not sufficent and barely visible. Especially for visually impaired people the focus indication was not accessible.
