### PR TITLE
fix: edge case where fetch button was visible when returned trains equaled to default trains count

### DIFF
--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -134,7 +134,7 @@ export function Station({ station, locale }: StationProps) {
             isLoading={train.isFetching}
             loadingText={t('loading')}
             disabled={train.isFetching}
-            visible={showFetchButton(train.data)}
+            visible={showFetchButton(train.data, count)}
             handleClick={() => setCount(count + 1, router.asPath)}
           >
             {t('buttons', 'fetchTrains')}

--- a/site/src/features/pages/station/helpers.ts
+++ b/site/src/features/pages/station/helpers.ts
@@ -16,13 +16,16 @@ import constants from '~/constants'
  * If the API responds with 191 trains in the above case, displaying the button is redundant and is hidden when index = 2.
  *
  * The case: `191 % 100 != 0`
+ *
+ * Additionally, `fetchCount` parameter may be used to deal with an edge case where new trains were fetched but the returned amount of trains is {@link constants.DEFAULT_TRAINS_COUNT}.
  */
-export function showFetchButton(trains?: unknown[]) {
+export function showFetchButton(trains?: unknown[], fetchCount = 0) {
   if (!trains || trains.length === 0) {
     return false
   }
 
-  const isPrimaryState = trains.length === constants.DEFAULT_TRAINS_COUNT
+  const isPrimaryState =
+    trains.length === constants.DEFAULT_TRAINS_COUNT && fetchCount === 0
   const hasMoreTrains = trains.length % constants.TRAINS_MULTIPLIER === 0
 
   return isPrimaryState || hasMoreTrains

--- a/site/tests/features/pages/station/helpers.test.ts
+++ b/site/tests/features/pages/station/helpers.test.ts
@@ -1,0 +1,40 @@
+import { showFetchButton } from '~/features/pages/station/helpers'
+
+import { it, expect, describe } from 'vitest'
+import { DEFAULT_TRAINS_COUNT, TRAINS_MULTIPLIER } from '~/constants'
+
+describe('show fetch button', () => {
+  it('is hidden when there are no trains', () => {
+    expect(showFetchButton([])).toBe(false)
+  })
+
+  it('is hidden if no parameters are supplied', () => {
+    expect(showFetchButton()).toBe(false)
+  })
+
+  it('is hidden when amount of trains equals to DEFAULT_TRAINS_COUNT and fetch count > 0', () => {
+    const fetchCount = 1 as const
+    const trains = Array.from({ length: DEFAULT_TRAINS_COUNT })
+
+    expect(showFetchButton(trains, fetchCount)).toBe(false)
+  })
+
+  it('is hidden when trains.length % TRAINS_MULTIPLIER != 0', () => {
+    // E.g. when trains were fetched for three times (n0 = 20, n1 = 100, n2 = 101)
+    const trains = Array.from({ length: TRAINS_MULTIPLIER + 1 })
+
+    expect(showFetchButton(trains)).toBe(false)
+  })
+
+  it('is visible when amount of trains equals to DEFAULT_TRAINS_COUNT and fetch count = 0', () => {
+    const trains = Array.from({ length: DEFAULT_TRAINS_COUNT })
+
+    expect(showFetchButton(trains)).toBe(true)
+  })
+
+  it('is visible when trains.length % TRAINS_MULTIPLIER = 0', () => {
+    const trains = Array.from({ length: TRAINS_MULTIPLIER })
+
+    expect(showFetchButton(trains)).toBe(true)
+  })
+})


### PR DESCRIPTION
- test: add show fetch button test
- fix: edge case where returned trains equaled to default trans count
