### PR TITLE
fix: show future timetable rows

### DIFF
--- a/site/src/components/errors/digitraffic/styles.tsx
+++ b/site/src/components/errors/digitraffic/styles.tsx
@@ -103,7 +103,7 @@ export const StyledListItem = styled('li', {
 export const StyledButton = styled('button', {
   background: '$primary900',
   color: '$primary100',
-  padding: '$xss $s',
+  padding: '$xxs $s',
   borderRadius: '9999px',
   '&:hover': {
     cursor: 'pointer'

--- a/site/src/components/errors/digitraffic/styles.tsx
+++ b/site/src/components/errors/digitraffic/styles.tsx
@@ -103,7 +103,7 @@ export const StyledListItem = styled('li', {
 export const StyledButton = styled('button', {
   background: '$primary900',
   color: '$primary100',
-  padding: '$xxs $s',
+  padding: '$xss $s',
   borderRadius: '9999px',
   '&:hover': {
     cursor: 'pointer'

--- a/site/src/utils/train.ts
+++ b/site/src/utils/train.ts
@@ -93,8 +93,9 @@ export const simplifyTrain = <
       ?.stationShortCode
   )
 
-  const timetableRow = train.timeTableRows.find(
-    tr => tr.stationShortCode === stationShortCode && tr.type === 'DEPARTURE'
+  const timetableRow = getFutureTimetableRow(
+    stationShortCode,
+    train.timeTableRows
   )
 
   const destinationStation = stations.find(
@@ -188,4 +189,25 @@ export const getTrainType = (code: Code, locale: Locale): string => {
     default:
       return t('train')
   }
+}
+
+/**
+ * Some trains might depart multiple times from a station. This function gets the timetable row that is closest to departing.
+ */
+export const getFutureTimetableRow = <
+  T extends { stationShortCode: string; scheduledTime: string; type: string }
+>(
+  stationShortCode: string,
+  timetableRows: T[],
+  type: 'DEPARTURE' | 'ARRIVAL' = 'DEPARTURE'
+): T => {
+  const stationTimetableRows = timetableRows.filter(
+    tr => tr.stationShortCode === stationShortCode && tr.type === type
+  )
+
+  return (
+    stationTimetableRows.find(({ scheduledTime }) => {
+      return +new Date(scheduledTime) - Date.now() > 0
+    }) || stationTimetableRows[stationTimetableRows.length - 1]
+  )
 }

--- a/site/src/utils/train.ts
+++ b/site/src/utils/train.ts
@@ -200,10 +200,14 @@ export const getFutureTimetableRow = <
   stationShortCode: string,
   timetableRows: T[],
   type: 'DEPARTURE' | 'ARRIVAL' = 'DEPARTURE'
-): T => {
+): T | undefined => {
   const stationTimetableRows = timetableRows.filter(
     tr => tr.stationShortCode === stationShortCode && tr.type === type
   )
+
+  if (stationTimetableRows.length === 0) {
+    return
+  }
 
   return (
     stationTimetableRows.find(({ scheduledTime }) => {

--- a/site/tests/utils/train.test.ts
+++ b/site/tests/utils/train.test.ts
@@ -8,7 +8,8 @@ import {
   getTrainType,
   simplifyTrains,
   simplifyTrain,
-  Codes
+  Codes,
+  getFutureTimetableRow
 } from '@utils/train'
 
 type Train = Parameters<typeof simplifyTrain>[0]
@@ -117,3 +118,29 @@ function hasExpectedProperties(train: SimplifiedTrain | SimplifiedTrain[]) {
   expect(_train.version).toStrictEqual(TRAIN.version)
   expect(_train.departureDate).toBe(TRAIN.departureDate)
 }
+
+describe('get future timetable row', () => {
+  it('returns timetable row that is in the future', () => {
+    const now = new Date()
+
+    const second = 1000
+    const minute = 60 * second
+    const hourBefore = new Date(Date.now() - 60 * minute)
+
+    const stationShortCode = 'PAS'
+    const type = 'DEPARTURE'
+
+    const timetableRows: {
+      scheduledTime: string
+      stationShortCode: string
+      type: string
+    }[] = [
+      { scheduledTime: `${hourBefore}`, stationShortCode, type },
+      { scheduledTime: `${now}`, stationShortCode, type }
+    ]
+
+    expect(
+      getFutureTimetableRow(stationShortCode, timetableRows)
+    ).toStrictEqual(timetableRows.at(1))
+  })
+})


### PR DESCRIPTION
Some trains might depart multiple times from a station, which resulted in incorrect timetable row being shown if there was multiple.

Fix by showing the timetable row that is in the future.