### PR TITLE
feat: analytics

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,9 +186,6 @@ importers:
       '@tanstack/react-query':
         specifier: 4.23.0
         version: 4.23.0(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
-      '@vercel/analytics':
-        specifier: ^0.1.11
-        version: 0.1.11(react@18.3.0-next-81d4ee9ca-20221223)
       '@vercel/og':
         specifier: ^0.3.0
         version: 0.3.0
@@ -6711,17 +6708,6 @@ packages:
       '@typescript-eslint/types': 5.49.0
       eslint-visitor-keys: 3.3.0
     dev: true
-
-  /@vercel/analytics@0.1.11(react@18.3.0-next-81d4ee9ca-20221223):
-    resolution: {integrity: sha512-mj5CPR02y0BRs1tN3oZcBNAX9a8NxsIUl9vElDPcqxnMfP0RbRc9fI9Ud7+QDg/1Izvt5uMumsr+6YsmVHcyuw==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || 18.x
-    peerDependenciesMeta:
-      react:
-        optional: true
-    dependencies:
-      react: 18.3.0-next-81d4ee9ca-20221223
-    dev: false
 
   /@vercel/og@0.3.0:
     resolution: {integrity: sha512-0L7tAgyLJWv2jdCg7NQtoWOs+ZK+pYeJBev3r1Y8apHjcu7Qj/OfR65JlAPfTMH8b6iUpVtBeHWVUo5KAhaC2A==}

--- a/site/package.json
+++ b/site/package.json
@@ -24,7 +24,6 @@
     "@radix-ui/react-toast": "1.1.2",
     "@sentry/nextjs": "7.34.0",
     "@tanstack/react-query": "4.23.0",
-    "@vercel/analytics": "^0.1.11",
     "@vercel/og": "^0.3.0",
     "core-js": "3.27.2",
     "formik": "^2.2.9",

--- a/site/src/features/pages/app/components/app.tsx
+++ b/site/src/features/pages/app/components/app.tsx
@@ -7,8 +7,6 @@ import constants from 'src/constants'
 
 import dynamic from 'next/dynamic'
 
-import { Analytics } from '@vercel/analytics/react'
-
 import { getLocale } from '@utils/get_locale'
 import { useWakeLock } from '@hooks/use_wake_lock'
 import translate from '@utils/translate'
@@ -38,8 +36,6 @@ export function App({ Component, pageProps }: AppProps) {
           <NoScript>
             {translate(getLocale(router.locale))('errors', 'nojs')}
           </NoScript>
-
-          <Analytics />
 
           <Component {...pageProps} />
         </Component.layout>

--- a/site/src/features/pages/document/components/document.tsx
+++ b/site/src/features/pages/document/components/document.tsx
@@ -15,6 +15,14 @@ export function Document() {
   return (
     <Html>
       <Head>
+        <script
+          async
+          defer
+          src="https://analytics.junat.live/script.js"
+          data-website-id="d9cc456e-d163-4432-991a-021091149b58"
+          // Prevents the tracking script from running on preview environment
+          data-domains="junat.live"
+        ></script>
         <link
           rel="apple-touch-icon"
           sizes="180x180"

--- a/site/src/hooks/use_analytics.ts
+++ b/site/src/hooks/use_analytics.ts
@@ -1,0 +1,49 @@
+import React from 'react'
+
+interface Umami {
+  /**
+   * Send a pageview event (this is done automatically)
+   */
+  track(): void
+  /**
+   * Send a event without payload, e.g. 'signup'
+   */
+  track(eventName: string): void
+  /**
+   * Send an event with a payload, e.g ('signup', {date: "2020-01-01"})
+   */
+  track(eventName: string, payload: Record<string, unknown> | string): void
+  /**
+   * Send an event with payload created with props collected by umami
+   */
+  track(
+    props: (
+      props: Props
+    ) => { website: string } & Partial<Props> & Record<string, unknown>
+  ): void
+}
+
+type Props = {
+  hostname: string
+  language: string
+  referrer: string
+  screen: string
+  title: string
+  url: string
+  website: string
+}
+
+/**
+ * Returns an analytics object to track events.
+ */
+export const useAnalytics = () => {
+  const [umami, setUmami] = React.useState<Umami>()
+
+  React.useEffect(() => {
+    if ('umami' in window) {
+      setUmami(window.umami as Umami)
+    }
+  }, [])
+
+  return umami
+}


### PR DESCRIPTION
Removed Vercel Analytics service in favor of self hosted Umami. Analytics will be used to understand which features to prioritize and are anonymous.