### PR TITLE
ci: dont run test on push to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,6 @@ name: Node.js test CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: ['main']
   workflow_call:
     secrets:
       TURBO_TOKEN:


### PR DESCRIPTION
this is a waste of time as branch protection rules ensure tests pass before merging
