### PR TITLE
test: better localization tests

### DIFF
--- a/site/src/locales/README.md
+++ b/site/src/locales/README.md
@@ -2,9 +2,8 @@
 
 1. Copy `en.json` as a starting point (or your native language)
 2. Add the locale to `src/constants/locales.js`, it should be the filename `<locale>.json`, also modify the JSDOC type annotation and `ROUTES` object
-3. Check if anything in `src/middleware.ts` needs to be updated as matcher values need to be static. 
-4. From the directory root run `node scripts/clear_stale_cache.js`
-5. Run `pnpm test 'locales'`.
+3. From the directory root run `node scripts/clear_stale_cache.js`
+4. Run `pnpm test 'locales'`.
 
 > **Warning**
 > Use [UTS Locale Identifiers](https://www.unicode.org/reports/tr35/tr35-59/tr35.html#Identifiers) in the file name.

--- a/site/tests/locales.test.ts
+++ b/site/tests/locales.test.ts
@@ -7,6 +7,10 @@ const MODULES: Record<string, any> = import.meta.glob('/src/locales/*.json', {
   import: 'default'
 })
 
+// There are rare cases where we might want to skip testing for a particular object
+// Format: [[keys for depth 0], [keys for depth 1]...]
+const SKIP_KEY = [['stations']]
+
 test('localizations have same keys max depth = 3', () => {
   const keys = Object.keys(MODULES)
 
@@ -16,34 +20,33 @@ test('localizations have same keys max depth = 3', () => {
     const aObj = MODULES[keys[prev]]
     const bObj = MODULES[keys[i]]
 
-    const d0_a = Object.keys(aObj).sort()
-    const d0_b = Object.keys(bObj).sort()
+    compareKeys(aObj, bObj, 0, 3)
+  }
+})
 
-    const message = `Expected ${keys[prev]} to have same keys as ${keys[i]}`
+function compareKeys(
+  aObj: { [x: string]: any },
+  bObj: { [x: string]: any },
+  depth: number,
+  maxDepth: number
+) {
+  SKIP_KEY.at(depth)?.every(keyToSkip => {
+    delete aObj[keyToSkip]
+    delete bObj[keyToSkip]
+  })
 
-    expect(d0_a, message).toStrictEqual(d0_b)
+  const aKeys = Object.keys(aObj).sort()
+  const bKeys = Object.keys(bObj).sort()
 
-    const d1 = d0_a.filter(key => typeof aObj[key] === 'object')
-    const SKIP_KEYS = { d1: 'stations' }
+  expect(aKeys).toStrictEqual(bKeys)
 
-    for (const d of d1) {
-      if (d === SKIP_KEYS.d1) {
-        continue
-      }
-
-      const d1_a = Object.keys(aObj[d]).sort()
-      const d1_b = Object.keys(bObj[d]).sort()
-
-      expect(d1_a).toStrictEqual(d1_b)
-
-      const d2 = d1_a.filter(key => typeof aObj[d][key] === 'object')
-
-      for (const d_2 of d2) {
-        const a = Object.keys(aObj[d][d_2]).sort()
-        const b = Object.keys(bObj[d][d_2]).sort()
-
-        expect(a).toStrictEqual(b)
+  if (depth < maxDepth) {
+    for (const key of aKeys) {
+      if (typeof aObj[key] === 'object') {
+        const aChild = aObj[key]
+        const bChild = bObj[key]
+        compareKeys(aChild, bChild, depth + 1, maxDepth)
       }
     }
   }
-})
+}

--- a/site/tests/locales.test.ts
+++ b/site/tests/locales.test.ts
@@ -2,21 +2,48 @@
 
 import { expect, test } from 'vitest'
 
-const MODULES: Record<string, JSON> = import.meta.glob('/src/locales/*.json', {
-  eager: true
+const MODULES: Record<string, any> = import.meta.glob('/src/locales/*.json', {
+  eager: true,
+  import: 'default'
 })
 
-test('localizations have same keys (Depth=0)', () => {
+test('localizations have same keys max depth = 3', () => {
   const keys = Object.keys(MODULES)
 
   for (let i = 0; i < keys.length; i++) {
     const prev = i !== 0 ? i - 1 : keys.length - 1
 
-    const a = Object.keys(MODULES[keys[prev]]).sort()
-    const b = Object.keys(MODULES[keys[i]]).sort()
+    const aObj = MODULES[keys[prev]]
+    const bObj = MODULES[keys[i]]
+
+    const d0_a = Object.keys(aObj).sort()
+    const d0_b = Object.keys(bObj).sort()
 
     const message = `Expected ${keys[prev]} to have same keys as ${keys[i]}`
 
-    expect(a, message).toStrictEqual(b)
+    expect(d0_a, message).toStrictEqual(d0_b)
+
+    const d1 = d0_a.filter(key => typeof aObj[key] === 'object')
+    const SKIP_KEYS = { d1: 'stations' }
+
+    for (const d of d1) {
+      if (d === SKIP_KEYS.d1) {
+        continue
+      }
+
+      const d1_a = Object.keys(aObj[d]).sort()
+      const d1_b = Object.keys(bObj[d]).sort()
+
+      expect(d1_a).toStrictEqual(d1_b)
+
+      const d2 = d1_a.filter(key => typeof aObj[d][key] === 'object')
+
+      for (const d_2 of d2) {
+        const a = Object.keys(aObj[d][d_2]).sort()
+        const b = Object.keys(bObj[d][d_2]).sort()
+
+        expect(a).toStrictEqual(b)
+      }
+    }
   }
 })


### PR DESCRIPTION
Now instead of just comparing the JSON root, compares all of the keys within the object. 

Before this would pass:
```json
[
  {
    "myKey": {
      "x": 1
    }
  },
  {
    "myKey": {}
  }
]
```

`x` is expected to be present on both objects but isn't. 