### PR TITLE
fix: reduce stale time

### DIFF
--- a/site/src/lib/digitraffic/hooks/use_live_trains.ts
+++ b/site/src/lib/digitraffic/hooks/use_live_trains.ts
@@ -47,13 +47,11 @@ export const useLiveTrains = (opts: {
     ).filter(train => train.commercialStop)
   }
 
-  return useQuery<SimplifiedTrain[], unknown>(
-    [`trains/${opts.path}`, opts.count],
+  return useQuery<SimplifiedTrain[], unknown>({
+    queryKey: [`trains/${opts.path}`, opts.count],
     queryFn,
-    {
-      enabled: opts.localizedStations.length > 0,
-      staleTime: 5 * 60 * 1000, // 5 minutes
-      keepPreviousData: true
-    }
-  )
+    enabled: opts.localizedStations.length > 0,
+    staleTime: 30 * 1000, // 30 seconds
+    keepPreviousData: true
+  })
 }


### PR DESCRIPTION
The stale time defined was way too large. It led to issues where the user might've navigated to another tab, navigated back only to be met with a blank screen. The only thing the user could do in this scenario was to reload the page. 

Decrease stale time from 5 minutes to 30 seconds.