### PR TITLE
chore: update turbo.json with better caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build Storybook
         if: matrix.node-version == '19.x'
-        run: pnpm -C site build-storybook --quiet
+        run: pnpm build-storybook -- --quiet
 
       - name: Serve Storybook and test with coverage
         if: matrix.node-version == '19.x'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "check-types": "turbo run check-types",
     "start": "turbo run start",
     "test": "turbo run test",
+    "build-storybook": "turbo run build-storybook",
     "coverage": "shx rm -rf coverage/** && pnpm run -C site \"/coverage(-storybook)?/\" && pnpm mv-coverage-output && c8 pnpm --filter=./packages/* test",
     "mv-coverage-output": "pnpx nyc report  --reporter=lcovonly -t site/coverage --report-dir coverage/ && shx mv coverage/lcov.info coverage/site.lcov.info"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -28,12 +28,9 @@
       "cache": false
     },
     "build-storybook": {
-      "dependsOn": [
-        "^build",
-        "**/*.stories.tsx",
-        "src/**/*.tsx",
-        "src/**/*.ts"
-      ],
+      "dependsOn": ["^build"],
+      "inputs": ["**/*.stories.tsx", "src/**/*.tsx", "src/**/*.ts"],
+      "outputMode": "new-only",
       "outputs": ["storybook-static"]
     },
     "start": {

--- a/turbo.json
+++ b/turbo.json
@@ -2,18 +2,25 @@
   "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
     "build": {
-      "dependsOn": ["^build", "gql-codegen"],
-      "outputs": [".next/**", "tmp/**", "dist/**"]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "outputMode": "new-only"
+    },
+    "site#build": {
+      "dependsOn": ["^build", "site#gql-codegen"],
+      "outputs": [".next/**", "!.next/cache/**"],
+      "outputMode": "new-only",
+      "env": ["NEXT_PUBLIC_SENTRY_DSN"]
     },
     "test": {
-      "dependsOn": ["^build", "gql-codegen"],
+      "dependsOn": ["^build", "site#gql-codegen"],
       "outputs": []
     },
     "lint": {
       "outputs": []
     },
     "check-types": {
-      "dependsOn": ["^build", "gql-codegen"],
+      "dependsOn": ["^build", "site#gql-codegen"],
       "outputs": ["**tsconfig.tsbuildinfo"]
     },
     "dev": {
@@ -21,11 +28,17 @@
       "cache": false
     },
     "start": {
-      "dependsOn": ["build", "gql-codegen"]
+      "dependsOn": ["build", "site#gql-codegen"]
     },
-    "gql-codegen": {
-      "outputs": ["./site/src/generated/**"],
-      "cache": false
+    "site#gql-codegen": {
+      "inputs": [
+        "src/generated/*",
+        "src/lib/digitraffic/{queries,fragments}/*",
+        "codegen.ts",
+        "package.json"
+      ],
+      "outputs": ["src/generated/*"],
+      "outputMode": "hash-only"
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,15 @@
       "dependsOn": ["^build"],
       "cache": false
     },
+    "build-storybook": {
+      "dependsOn": [
+        "^build",
+        "**/*.stories.tsx",
+        "src/**/*.tsx",
+        "src/**/*.ts"
+      ],
+      "outputs": ["storybook-static"]
+    },
     "start": {
       "dependsOn": ["build", "site#gql-codegen"]
     },


### PR DESCRIPTION
- correctly cache gql-codegen, meaning that `site#build` does not need to run everytime
- change output mode for tasks to simplify stdout
- cache storybook builds, these take upto a minute to complete and don't change often
