### PR TITLE
fix: minor ui tweaks

### DIFF
--- a/site/src/components/buttons/animated_background.tsx
+++ b/site/src/components/buttons/animated_background.tsx
@@ -32,7 +32,7 @@ export default function AnimatedButton(props: AnimatedButtonProps) {
           className={`overflow-hidden relative select-none cursor-pointer z-[1] border-solid border-[1px]
           border-primary-600 text-primary-800 py-[0.3125rem] px-[1.25rem] rounded-full disabled:cursor-not-allowed
           disabled:bg-gray-100 disabled:border-primary-300 dark:bg-gray-900 dark:border-primary-400 dark:text-primary-200
-          dark:disabled:bg-gray-900 dark:disabled:border-primary-800 mx-auto`}
+          dark:disabled:bg-gray-900 dark:disabled:border-primary-800 mx-auto font-ui`}
           whileTap={{ scale: isLoading ? 1 : 1.1 }}
           whileHover={{ scale: isLoading ? 1 : 1.05 }}
           initial={{ opacity: 0, scale: 0.95 }}

--- a/site/src/components/timetables/timetable_row/index.tsx
+++ b/site/src/components/timetables/timetable_row/index.tsx
@@ -127,11 +127,11 @@ export function TimetableRow({
       opacity: [0, 1]
     }
 
-    controls.start(fadeIn)
-
-    if (isLastStation) {
-      controls.start(backgroundAnimation, { duration: 0.5 })
-    }
+    controls.start(fadeIn).then(() => {
+      if (isLastStation) {
+        controls.start(backgroundAnimation, { duration: 0.75 })
+      }
+    })
   }, [controls, dark, isLastStation, primary200, primary800, gray100, gray900])
 
   return (

--- a/site/src/components/timetables/timetable_row/index.tsx
+++ b/site/src/components/timetables/timetable_row/index.tsx
@@ -129,7 +129,7 @@ export function TimetableRow({
 
     controls.start(fadeIn).then(() => {
       if (isLastStation) {
-        controls.start(backgroundAnimation, { duration: 0.75 })
+        controls.start(backgroundAnimation, { duration: 0.5 })
       }
     })
   }, [controls, dark, isLastStation, primary200, primary800, gray100, gray900])

--- a/site/src/components/timetables/timetable_row/index.tsx
+++ b/site/src/components/timetables/timetable_row/index.tsx
@@ -93,7 +93,7 @@ export function TimetableRow({
   animation
 }: TimetableRowProps) {
   const { '100': gray100, '900': gray900 } = theme.colors.gray
-  const { '200': primary200, '900': primary800 } = theme.colors.primary
+  const { '200': primary200, '800': primary800 } = theme.colors.primary
 
   const { scheduledTime, liveEstimateTime } = {
     scheduledTime: getFormattedTime(train.scheduledTime),

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -122,7 +122,7 @@ export function Station({ station, locale }: StationProps) {
             })}
           </p>
         )}
-        {train.isFetching && <Spinner fixedToCenter />}
+        {train.isFetching && trains.length === 0 && <Spinner fixedToCenter />}
         <Timetable
           locale={locale}
           trains={sortSimplifiedTrains(trains)}
@@ -133,7 +133,7 @@ export function Station({ station, locale }: StationProps) {
             isLoading={train.isFetching}
             loadingText={t('loading')}
             disabled={train.isFetching}
-            visible={showFetchButton(train.data, count)}
+            visible={showFetchButton(train.data, train.isFetching, count)}
             handleClick={() => setCount(count + 1, router.asPath)}
           >
             {t('buttons', 'fetchTrains')}

--- a/site/src/features/pages/station/helpers.ts
+++ b/site/src/features/pages/station/helpers.ts
@@ -1,7 +1,8 @@
 import constants from '~/constants'
 
 /**
- * The fetch button should only be visible if there are trains to be fetched.
+ * The fetch button should only be visible if there are trains to be fetched or when trains are being fetched.
+ * The button will be always visible when `isLoading = true` and there are trains.
  *
  * 1. If there are no trains the button must be hidden.
  * 2. If there are initial trains ({@link constants.DEFAULT_TRAINS_COUNT|view default}) show the button.
@@ -19,9 +20,17 @@ import constants from '~/constants'
  *
  * Additionally, `fetchCount` parameter may be used to deal with an edge case where new trains were fetched but the returned amount of trains is {@link constants.DEFAULT_TRAINS_COUNT}.
  */
-export function showFetchButton(trains?: unknown[], fetchCount = 0) {
+export function showFetchButton(
+  trains?: unknown[],
+  isLoading = false,
+  fetchCount = 0
+) {
   if (!trains || trains.length === 0) {
     return false
+  }
+
+  if (isLoading) {
+    return true
   }
 
   const isPrimaryState =

--- a/site/tests/features/pages/station/helpers.test.ts
+++ b/site/tests/features/pages/station/helpers.test.ts
@@ -16,7 +16,7 @@ describe('show fetch button', () => {
     const fetchCount = 1 as const
     const trains = Array.from({ length: DEFAULT_TRAINS_COUNT })
 
-    expect(showFetchButton(trains, fetchCount)).toBe(false)
+    expect(showFetchButton(trains, false, fetchCount)).toBe(false)
   })
 
   it('is hidden when trains.length % TRAINS_MULTIPLIER != 0', () => {


### PR DESCRIPTION
Use `ui` font for primary button

| Old | New |
|--------|--------|
| ![image](https://github.com/jqpe/junat.live/assets/65775308/3693a4f3-a836-4b50-8013-f899b5246825) | ![image](https://github.com/jqpe/junat.live/assets/65775308/5255ca35-ba97-4f33-b184-3d1e73d20464) | 

Loading spinner only appears once when fetching initial trains. 
When fetching more trains, the loading state is kept in the fetch button which was the behavior almost a year ago. Since the spinner can not be opaque, it will clash with timetable row separators, making it look kind of cheap, this fixes that.

Fix using wrong color for timetable row focus indicator when on dark mode. Also fixes an issue where the focus indicator was not visible by running animations successively instead of parallelly.