### PR TITLE
fix: use shallow comparision to avoid re-renders

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         version: 4.9.4
       vite:
         specifier: ^4.4.9
-        version: 4.4.9(@types/node@18.11.18)
+        version: 4.4.9(@types/node@18.14.6)
       vitest:
         specifier: 0.34.6
         version: 0.34.6(jsdom@21.1.0)(playwright@1.38.1)
@@ -272,6 +272,9 @@ importers:
       '@storybook/test-runner':
         specifier: ^0.13.0
         version: 0.13.0(@types/node@18.11.18)(ts-node@10.9.1)
+      '@storybook/testing-library':
+        specifier: ^0.2.2
+        version: 0.2.2
       '@svgr/webpack':
         specifier: ^6.5.1
         version: 6.5.1
@@ -413,7 +416,7 @@ packages:
       '@babel/core': 7.22.20
       '@babel/generator': 7.22.15
       '@babel/parser': 7.22.16
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@babel/traverse': 7.22.20
       '@babel/types': 7.23.0
       babel-preset-fbjs: 3.4.0(@babel/core@7.22.20)
@@ -5543,7 +5546,7 @@ packages:
   /@radix-ui/number@1.0.1:
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
     dev: true
 
   /@radix-ui/primitive@1.0.0:
@@ -5568,7 +5571,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.1(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       react: 18.3.0-next-81d4ee9ca-20221223
       react-dom: 18.3.0-next-81d4ee9ca-20221223(react@18.3.0-next-81d4ee9ca-20221223)
@@ -5591,7 +5594,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@types/react': 18.0.27
       '@types/react-dom': 18.0.10
@@ -5635,7 +5638,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-context': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
@@ -5754,7 +5757,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@types/react': 18.0.27
       react: 18.3.0-next-81d4ee9ca-20221223
 
@@ -5796,7 +5799,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
@@ -5891,7 +5894,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@types/react': 18.0.27
       react: 18.3.0-next-81d4ee9ca-20221223
 
@@ -5931,7 +5934,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
@@ -6084,7 +6087,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@floating-ui/react-dom': 2.0.2(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-arrow': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
@@ -6169,7 +6172,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@types/react': 18.0.27
       '@types/react-dom': 18.0.10
@@ -6237,7 +6240,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@types/react': 18.0.27
@@ -6304,7 +6307,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
@@ -6420,7 +6423,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@types/react': 18.0.27
       '@types/react-dom': 18.0.10
@@ -6452,7 +6455,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@types/react': 18.0.27
       react: 18.3.0-next-81d4ee9ca-20221223
@@ -6533,7 +6536,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-context': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-direction': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
@@ -6564,7 +6567,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/primitive': 1.0.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
@@ -6628,7 +6631,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@types/react': 18.0.27
       react: 18.3.0-next-81d4ee9ca-20221223
 
@@ -6669,7 +6672,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-callback-ref': 1.0.0(react@18.3.0-next-81d4ee9ca-20221223)
       react: 18.3.0-next-81d4ee9ca-20221223
     dev: false
@@ -6685,7 +6688,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.0.27)(react@18.3.0-next-81d4ee9ca-20221223)
       '@types/react': 18.0.27
       react: 18.3.0-next-81d4ee9ca-20221223
@@ -6713,7 +6716,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@types/react': 18.0.27
       react: 18.3.0-next-81d4ee9ca-20221223
 
@@ -6752,7 +6755,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/rect': 1.0.0
       react: 18.3.0-next-81d4ee9ca-20221223
     dev: false
@@ -6768,7 +6771,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/rect': 1.0.1
       '@types/react': 18.0.27
       react: 18.3.0-next-81d4ee9ca-20221223
@@ -6781,7 +6784,7 @@ packages:
       react:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-use-layout-effect': 1.0.0(react@18.3.0-next-81d4ee9ca-20221223)
       react: 18.3.0-next-81d4ee9ca-20221223
     dev: false
@@ -6836,7 +6839,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223)
       '@types/react': 18.0.27
       '@types/react-dom': 18.0.10
@@ -6847,13 +6850,13 @@ packages:
   /@radix-ui/rect@1.0.0:
     resolution: {integrity: sha512-d0O68AYy/9oeEy1DdC07bz1/ZXX+DqCskRd3i4JzLSTXwefzaepQrKjXC7aNM8lTHjFLDO0pDgaEiQ7jEk+HVg==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
     dev: false
 
   /@radix-ui/rect@1.0.1:
     resolution: {integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
 
   /@repeaterjs/repeater@3.0.4:
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
@@ -8407,6 +8410,14 @@ packages:
       - ts-node
     dev: true
 
+  /@storybook/testing-library@0.2.2:
+    resolution: {integrity: sha512-L8sXFJUHmrlyU2BsWWZGuAjv39Jl1uAqUHdxmN42JY15M4+XCMjGlArdCCjDe1wpTSW6USYISA9axjZojgtvnw==}
+    dependencies:
+      '@testing-library/dom': 9.3.3
+      '@testing-library/user-event': 14.5.1(@testing-library/dom@9.3.3)
+      ts-dedent: 2.2.0
+    dev: true
+
   /@storybook/theming@7.4.5(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223):
     resolution: {integrity: sha512-QSIJDIMzOegzlhubIBaYIovf4mlf+AVL0SmQOskPS8GZ6s9t77yUUI6gZTEjO+S4eB3djXRsfTTijQ8+z4XmRA==}
     peerDependencies:
@@ -8761,6 +8772,20 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@testing-library/dom@9.3.3:
+    resolution: {integrity: sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/runtime': 7.23.1
+      '@types/aria-query': 5.0.1
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+    dev: true
+
   /@testing-library/react@13.4.0(react-dom@18.3.0-next-81d4ee9ca-20221223)(react@18.3.0-next-81d4ee9ca-20221223):
     resolution: {integrity: sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==}
     engines: {node: '>=12'}
@@ -8778,6 +8803,15 @@ packages:
       '@types/react-dom': 18.0.10
       react: 18.3.0-next-81d4ee9ca-20221223
       react-dom: 18.3.0-next-81d4ee9ca-20221223(react@18.3.0-next-81d4ee9ca-20221223)
+    dev: true
+
+  /@testing-library/user-event@14.5.1(@testing-library/dom@9.3.3):
+    resolution: {integrity: sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 9.3.3
     dev: true
 
   /@tootallnate/once@2.0.0:
@@ -15563,6 +15597,11 @@ packages:
     hasBin: true
     dev: true
 
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+    dev: true
+
   /magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
@@ -17631,13 +17670,13 @@ packages:
   /regenerator-transform@0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
     dev: true
 
   /regenerator-transform@0.15.2:
     resolution: {integrity: sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
     dev: true
 
   /regex-parser@2.2.11:
@@ -17717,7 +17756,7 @@ packages:
   /relay-runtime@12.0.0:
     resolution: {integrity: sha512-QU6JKr1tMsry22DXNy9Whsq5rmvwr3LSZiiWV/9+DFpuTWvp+WFhobWMc8TC4OjKFfNhEZy7mOiqUAn5atQtug==}
     dependencies:
-      '@babel/runtime': 7.21.0
+      '@babel/runtime': 7.23.1
       fbjs: 3.0.5
       invariant: 2.2.4
     transitivePeerDependencies:

--- a/site/package.json
+++ b/site/package.json
@@ -65,6 +65,7 @@
     "@storybook/nextjs": "7.4.5",
     "@storybook/react": "^7.4.5",
     "@storybook/test-runner": "^0.13.0",
+    "@storybook/testing-library": "^0.2.2",
     "@svgr/webpack": "^6.5.1",
     "@testing-library/react": "^13.4.0",
     "@types/js-cookie": "^3.0.2",

--- a/site/src/components/input/station_dropdown_menu/index.tsx
+++ b/site/src/components/input/station_dropdown_menu/index.tsx
@@ -1,5 +1,8 @@
 import type { Locale } from '~/types/common'
 
+import Link from 'next/link'
+import { shallow } from 'zustand/shallow'
+
 import {
   Arrow,
   CheckboxItem,
@@ -9,12 +12,12 @@ import {
   Root,
   Trigger
 } from '@radix-ui/react-dropdown-menu'
+
 import CirclesHorizontal from '~/components/icons/circles_horizontal.svg'
+import GoogleMaps from '~/components/icons/google_maps.svg'
 import HeartFilled from '~/components/icons/heart_filled.svg'
 import HeartOutline from '~/components/icons/heart_outline.svg'
-import GoogleMaps from '~/components/icons/google_maps.svg'
 
-import Link from 'next/link'
 import { useFavorites } from '~/hooks/use_favorites'
 import { googleMapsDirections } from '~/utils/services'
 import translate from '~/utils/translate'
@@ -29,11 +32,14 @@ type StationDropdownMenuProps = {
 }
 
 export const StationDropdownMenu = (props: StationDropdownMenuProps) => {
-  const favorites = useFavorites(state => ({
-    add: state.addFavorite,
-    remove: state.removeFavorite,
-    has: state.isFavorite
-  }))
+  const favorites = useFavorites(
+    state => ({
+      add: state.addFavorite,
+      remove: state.removeFavorite,
+      has: state.isFavorite
+    }),
+    shallow
+  )
 
   const isFavorite = favorites.has(props.currentStation)
   const t = translate(props.locale)

--- a/site/src/components/input/station_dropdown_menu/index.tsx
+++ b/site/src/components/input/station_dropdown_menu/index.tsx
@@ -35,13 +35,15 @@ export const StationDropdownMenu = (props: StationDropdownMenuProps) => {
   const favorites = useFavorites(
     state => ({
       add: state.addFavorite,
-      remove: state.removeFavorite,
-      has: state.isFavorite
+      remove: state.removeFavorite
     }),
     shallow
   )
 
-  const isFavorite = favorites.has(props.currentStation)
+  const isFavorite = useFavorites(state => {
+    return state.isFavorite(props.currentStation)
+  })
+
   const t = translate(props.locale)
 
   return (

--- a/site/src/components/input/station_dropdown_menu/index.tsx
+++ b/site/src/components/input/station_dropdown_menu/index.tsx
@@ -31,6 +31,9 @@ type StationDropdownMenuProps = {
   lat: number
 }
 
+export const CHECKBOX_ITEM_TEST_ID = 'favorites-checkbox-item' as const
+export const TRIGGER_BUTTON_TEST_ID = 'trigger-button' as const
+
 export const StationDropdownMenu = (props: StationDropdownMenuProps) => {
   const favorites = useFavorites(
     state => ({
@@ -50,6 +53,7 @@ export const StationDropdownMenu = (props: StationDropdownMenuProps) => {
     <Root>
       <Trigger asChild>
         <button
+          data-testid={TRIGGER_BUTTON_TEST_ID}
           className="rounded-full h-[35px] w-[35px] inline-flex items-center justify-center text-primary-900 bg-gray-300 cursor-pointer fill-gray-800
           dark:fill-gray-400 dark:bg-gray-700 focus:outline-none focus:[border:2px_solid_theme(colors.primary.500)]"
           aria-label="Customise options"
@@ -71,6 +75,7 @@ export const StationDropdownMenu = (props: StationDropdownMenuProps) => {
           <Arrow className="dark:fill-gray-800 fill-gray-400" />
 
           <CheckboxItem
+            data-testid={CHECKBOX_ITEM_TEST_ID}
             className="group px-3 rounded-sm select-none transition-[background-color] duration-200 grid grid-cols-[1fr,24px]
             items-center cursor-pointer min-h-[35px] text-[13px] font-ui"
             // Prevents the menu from closing

--- a/site/src/components/input/station_dropdown_menu/station_dropdown_menu.stories.tsx
+++ b/site/src/components/input/station_dropdown_menu/station_dropdown_menu.stories.tsx
@@ -1,12 +1,54 @@
 import { Meta } from '@storybook/react'
-import { StationDropdownMenu } from '.'
+import {
+  StationDropdownMenu,
+  CHECKBOX_ITEM_TEST_ID,
+  TRIGGER_BUTTON_TEST_ID
+} from '.'
+import { within, fireEvent } from '@storybook/testing-library'
+import { useFavorites } from '~/hooks/use_favorites'
 
 export const Default = () => {
+  const removeFavorite = useFavorites(state => state.removeFavorite)
+  removeFavorite('HKI')
+
   return (
     <StationDropdownMenu currentStation="HKI" locale="en" long={1} lat={1} />
   )
 }
 
-export default { component: StationDropdownMenu } satisfies Meta<
-  typeof StationDropdownMenu
->
+export default {
+  component: StationDropdownMenu,
+  play: async context => {
+    const canvas = within(context.canvasElement)
+    const trigger = await canvas.findByTestId(TRIGGER_BUTTON_TEST_ID)
+
+    const pointerDown = new MouseEvent('pointerdown', { bubbles: true })
+    const keyDown = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true
+    })
+
+    fireEvent(trigger, pointerDown)
+
+    // "escape" the canvas since the content is portaled
+    const body = document.querySelector('body')
+
+    if (!body) {
+      throw new TypeError('body should exist')
+    }
+
+    const checkbox = await within(body).findByTestId(CHECKBOX_ITEM_TEST_ID)
+
+    if (checkbox.dataset.state === 'checked') {
+      throw new TypeError('Should not be checked by default')
+    }
+
+    checkbox.focus()
+
+    fireEvent(checkbox, keyDown)
+
+    if (checkbox.dataset.state !== 'checked') {
+      throw new TypeError('Should be checked when keydown')
+    }
+  }
+} satisfies Meta<typeof StationDropdownMenu>

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo } from 'react'
 
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
+import { shallow } from 'zustand/shallow'
 
 import { sortSimplifiedTrains } from '@utils/train'
 import translate from '@utils/translate'
@@ -44,11 +45,14 @@ export function Station({ station, locale }: StationProps) {
   const timetableRowId = useTimetableRow(state => state.timetableRowId)
 
   const router = useRouter()
-  const [count, setCount, setCurrentShortCode] = useStationPage(state => [
-    state.getCount(router.asPath) || 0,
-    state.setCount,
-    state.setCurrentShortCode
-  ])
+  const [count, setCount, setCurrentShortCode] = useStationPage(
+    state => [
+      state.getCount(router.asPath) || 0,
+      state.setCount,
+      state.setCurrentShortCode
+    ],
+    shallow
+  )
 
   const { data: stations = [], ...stationsQuery } = useStations()
 

--- a/site/src/features/toast/components/toast.tsx
+++ b/site/src/features/toast/components/toast.tsx
@@ -1,12 +1,13 @@
 import { AnimatePresence, motion } from 'framer-motion'
+import { shallow } from 'zustand/shallow'
 
 import CloseIcon from '@components/icons/close.svg'
 
 import { useColorScheme } from '@hooks/use_color_scheme'
 
 import {
-  ToastClose,
   Root,
+  ToastClose,
   ToastTitle,
   ToastViewport
 } from '@radix-ui/react-toast'
@@ -19,7 +20,10 @@ export interface ToastProps {
 
 export function Toast({ handleOpenChange }: ToastProps) {
   const { colorScheme } = useColorScheme()
-  const [toast, close] = useToast(state => [state.current, state.close])
+  const [toast, close] = useToast(
+    state => [state.current, state.close],
+    shallow
+  )
 
   return (
     <>


### PR DESCRIPTION
https://github.com/pmndrs/zustand/tree/v4.3.2#selecting-multiple-state-slices

By creating new state slices and not changing the comparision algorithm [we are essentially importing the whole store](https://tkdodo.eu/blog/working-with-zustand#prefer-atomic-selectors). Using shallow comparision is a migitation for this, but using atomic states by default should be considered in the future.

```
> y = {w:0}
{ w: 0 }
> y === {w:0}
false
> // a re-render is triggered for the entire store
```