### PR TITLE
fix: timetable row and search bar styles

### DIFF
--- a/site/src/components/timetables/timetable_row/index.tsx
+++ b/site/src/components/timetables/timetable_row/index.tsx
@@ -58,12 +58,7 @@ export interface TimetableRowProps {
 }
 
 const Anchor = (props: LinkProps & { children?: React.ReactNode }) => {
-  return (
-    <Link
-      {...props}
-      className="text-gray-800 cursor-pointer dark:text-gray-200 hover:text-primary-600 focus:text-primary-600"
-    />
-  )
+  return <Link {...props} />
 }
 
 const Time = (props: React.HTMLProps<HTMLTimeElement>) => (

--- a/site/src/features/search/components/search_bar.tsx
+++ b/site/src/features/search/components/search_bar.tsx
@@ -55,7 +55,7 @@ export function SearchBar<T extends { stationName: Record<Locale, string> }>({
         }}
       >
         <input
-          className="text-[1rem] [&:focus::-webkit-search-cancel-button]:[display:none]"
+          className="text-[1rem] [&:focus::-webkit-search-cancel-button]:[display:none] grow max-w-[calc(100%-32px)]"
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="none"


### PR DESCRIPTION
- fix: search bar styles

| Old | New |
|--------|--------|
| ![image](https://github.com/jqpe/junat.live/assets/65775308/c9dd199a-6bd4-4a64-a7b9-a77734cb07e2) | ![image](https://github.com/jqpe/junat.live/assets/65775308/72097367-1407-4b70-933f-f6873edd82b9) |
| ![image](https://github.com/jqpe/junat.live/assets/65775308/53efe377-36b0-43a3-8b9b-475dc6931bd6) | ![image](https://github.com/jqpe/junat.live/assets/65775308/0df1a941-5942-4782-950d-ecb7d7caab87) |

Now the form input also correctly expands to take up all the available space so clicking it is less confusing. We don't actually use a div for the input, it's just the underlying shadow dom implementation that I had enabled on devtools.


- fix: timetable row station link hover color

Fixes link styles by removing custom styles and relying on globals
