### PR TITLE
fix: mqtt bugs

### DIFF
--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -70,11 +70,15 @@ export function Station({ station, locale }: StationProps) {
   const from = locale === 'fi' ? From(fromStation) : fromStation
   const to = locale === 'fi' && toStation ? To(toStation) : toStation
 
+  // Keep track of the fetched trains since cache may be changed affecting length, used for `showFetchButton` logic.
+  const [actualLength, setActualLength] = React.useState(0)
+
   const train = useLiveTrains({
     count,
     filters: {
       destination
     },
+    onSuccess: trains => setActualLength(trains.length),
     localizedStations: stations,
     stationShortCode: station.stationShortCode,
     path: router.asPath
@@ -152,7 +156,7 @@ export function Station({ station, locale }: StationProps) {
             isLoading={train.isFetching}
             loadingText={t('loading')}
             disabled={train.isFetching}
-            visible={showFetchButton(train.data, train.isFetching, count)}
+            visible={showFetchButton(actualLength, train.isFetching, count)}
             handleClick={() => setCount(count + 1, router.asPath)}
           >
             {t('buttons', 'fetchTrains')}

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -1,7 +1,7 @@
 import type { LocalizedStation } from '@lib/digitraffic'
 import type { Locale } from '@typings/common'
 
-import React, { useEffect, useMemo } from 'react'
+import React from 'react'
 
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
@@ -35,7 +35,6 @@ import { From, To } from 'frominto'
 import { ErrorMessageWithRetry } from '~/components/error_message'
 import { StationDropdownMenu } from '~/components/station_dropdown_menu'
 import { useFilters } from '~/hooks/use_filters'
-import { SimplifiedTrain } from '~/types/simplified_train'
 
 export type StationProps = {
   station: LocalizedStation
@@ -58,7 +57,7 @@ export function Station({ station, locale }: StationProps) {
   const { data: stations = [], ...stationsQuery } = useStations()
   const destination = useFilters(state => state.destination)
 
-  useEffect(
+  React.useEffect(
     () => setCurrentShortCode(station.stationShortCode),
     [setCurrentShortCode, station.stationShortCode]
   )
@@ -81,28 +80,17 @@ export function Station({ station, locale }: StationProps) {
     path: router.asPath
   })
 
+  const trains = train.data ?? []
+
   const empty = train.isSuccess && train.data.length === 0
-
-  const [trains, setTrains] = React.useState<SimplifiedTrain[]>(
-    train.data ?? []
-  )
-
-  if (train.data && train.data !== trains) {
-    setTrains(train.data)
-  }
 
   useLiveTrainsSubscription({
     stationShortCode: station.stationShortCode,
     stations,
-    trains,
-    setTrains
+    queryKey: useLiveTrains.queryKey
   })
 
   const t = translate(locale)
-
-  useMemo(() => {
-    if (train.data) setTrains(train.data)
-  }, [train.data, setTrains])
 
   const errorQuery = getErrorQuery([stationsQuery, train])
 

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -1,7 +1,7 @@
 import type { LocalizedStation } from '@lib/digitraffic'
 import type { Locale } from '@typings/common'
 
-import { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
@@ -35,6 +35,7 @@ import { From, To } from 'frominto'
 import { ErrorMessageWithRetry } from '~/components/error_message'
 import { StationDropdownMenu } from '~/components/station_dropdown_menu'
 import { useFilters } from '~/hooks/use_filters'
+import { SimplifiedTrain } from '~/types/simplified_train'
 
 export type StationProps = {
   station: LocalizedStation
@@ -82,10 +83,19 @@ export function Station({ station, locale }: StationProps) {
 
   const empty = train.isSuccess && train.data.length === 0
 
-  const [trains, setTrains] = useLiveTrainsSubscription({
+  const [trains, setTrains] = React.useState<SimplifiedTrain[]>(
+    train.data ?? []
+  )
+
+  if (train.data && train.data !== trains) {
+    setTrains(train.data)
+  }
+
+  useLiveTrainsSubscription({
     stationShortCode: station.stationShortCode,
     stations,
-    initialTrains: train.data ?? []
+    trains,
+    setTrains
   })
 
   const t = translate(locale)

--- a/site/src/features/pages/station/helpers.ts
+++ b/site/src/features/pages/station/helpers.ts
@@ -21,11 +21,11 @@ import constants from '~/constants'
  * Additionally, `fetchCount` parameter may be used to deal with an edge case where new trains were fetched but the returned amount of trains is {@link constants.DEFAULT_TRAINS_COUNT}.
  */
 export function showFetchButton(
-  trains?: unknown[],
+  trains: number,
   isLoading = false,
   fetchCount = 0
 ) {
-  if (!trains || trains.length === 0) {
+  if (trains === 0) {
     return false
   }
 
@@ -34,8 +34,8 @@ export function showFetchButton(
   }
 
   const isPrimaryState =
-    trains.length === constants.DEFAULT_TRAINS_COUNT && fetchCount === 0
-  const hasMoreTrains = trains.length % constants.TRAINS_MULTIPLIER === 0
+    trains === constants.DEFAULT_TRAINS_COUNT && fetchCount === 0
+  const hasMoreTrains = trains % constants.TRAINS_MULTIPLIER === 0
 
   return isPrimaryState || hasMoreTrains
 }

--- a/site/src/features/pages/station/tests/helpers.test.ts
+++ b/site/src/features/pages/station/tests/helpers.test.ts
@@ -5,35 +5,31 @@ import { DEFAULT_TRAINS_COUNT, TRAINS_MULTIPLIER } from '~/constants'
 
 describe('show fetch button', () => {
   it('is hidden when there are no trains', () => {
-    expect(showFetchButton([])).toBe(false)
-  })
-
-  it('is hidden if no parameters are supplied', () => {
-    expect(showFetchButton()).toBe(false)
+    expect(showFetchButton(0)).toBe(false)
   })
 
   it('is hidden when amount of trains equals to DEFAULT_TRAINS_COUNT and fetch count > 0', () => {
     const fetchCount = 1 as const
-    const trains = Array.from({ length: DEFAULT_TRAINS_COUNT })
+    const trains = DEFAULT_TRAINS_COUNT
 
     expect(showFetchButton(trains, false, fetchCount)).toBe(false)
   })
 
   it('is hidden when trains.length % TRAINS_MULTIPLIER != 0', () => {
     // E.g. when trains were fetched for three times (n0 = 20, n1 = 100, n2 = 101)
-    const trains = Array.from({ length: TRAINS_MULTIPLIER + 1 })
+    const trains = TRAINS_MULTIPLIER + 1
 
     expect(showFetchButton(trains)).toBe(false)
   })
 
   it('is visible when amount of trains equals to DEFAULT_TRAINS_COUNT and fetch count = 0', () => {
-    const trains = Array.from({ length: DEFAULT_TRAINS_COUNT })
+    const trains = DEFAULT_TRAINS_COUNT
 
     expect(showFetchButton(trains)).toBe(true)
   })
 
   it('is visible when trains.length % TRAINS_MULTIPLIER = 0', () => {
-    const trains = Array.from({ length: TRAINS_MULTIPLIER })
+    const trains = TRAINS_MULTIPLIER
 
     expect(showFetchButton(trains)).toBe(true)
   })

--- a/site/src/lib/digitraffic/hooks/use_live_trains.ts
+++ b/site/src/lib/digitraffic/hooks/use_live_trains.ts
@@ -16,6 +16,7 @@ export function useLiveTrains(opts: {
   stationShortCode: string
   path: string
   filters?: { destination: string | null }
+  onSuccess?: (data: SimplifiedTrain[]) => void
   arrived?: number
   arriving?: number
   departed?: number
@@ -81,6 +82,7 @@ export function useLiveTrains(opts: {
   return useQuery<SimplifiedTrain[], unknown>({
     queryKey: useLiveTrains.queryKey,
     queryFn,
+    onSuccess: opts.onSuccess,
     enabled: opts.localizedStations.length > 0,
     staleTime: 30 * 1000, // 30 seconds
     keepPreviousData: true

--- a/site/src/lib/digitraffic/hooks/use_live_trains.ts
+++ b/site/src/lib/digitraffic/hooks/use_live_trains.ts
@@ -1,8 +1,8 @@
 import type { SimplifiedTrain } from '@typings/simplified_train'
 import type { LocalizedStation } from '../types'
 
-import { useQuery } from '@tanstack/react-query'
 import { fetchWithError } from '@junat/digitraffic'
+import { useQuery } from '@tanstack/react-query'
 
 import { simplifyTrains } from '@utils/train'
 import { DEFAULT_TRAINS_COUNT, TRAINS_MULTIPLIER } from 'src/constants'
@@ -10,7 +10,7 @@ import { DEFAULT_TRAINS_COUNT, TRAINS_MULTIPLIER } from 'src/constants'
 import { client } from '../helpers/graphql_request'
 import { normalizeTrains, trains } from '../queries/live_trains'
 
-export const useLiveTrains = (opts: {
+export function useLiveTrains(opts: {
   count: number
   localizedStations: LocalizedStation[]
   stationShortCode: string
@@ -19,7 +19,9 @@ export const useLiveTrains = (opts: {
   arrived?: number
   arriving?: number
   departed?: number
-}) => {
+}) {
+  useLiveTrains.queryKey = [`trains/${opts.path}`, opts.count, opts.filters]
+
   const queryFn = async () => {
     if (opts.filters?.destination) {
       const from = opts.stationShortCode
@@ -77,10 +79,12 @@ export const useLiveTrains = (opts: {
   }
 
   return useQuery<SimplifiedTrain[], unknown>({
-    queryKey: [`trains/${opts.path}`, opts.count, opts.filters],
+    queryKey: useLiveTrains.queryKey,
     queryFn,
     enabled: opts.localizedStations.length > 0,
     staleTime: 30 * 1000, // 30 seconds
     keepPreviousData: true
   })
 }
+
+useLiveTrains.queryKey = [] as unknown[]

--- a/site/src/lib/digitraffic/hooks/use_live_trains_subscription.ts
+++ b/site/src/lib/digitraffic/hooks/use_live_trains_subscription.ts
@@ -43,17 +43,17 @@ export const useLiveTrainsSubscription = ({
 
     ;(async () => {
       for await (const updatedTrain of client.trains) {
-        setTrains(oldTrains => {
-          const matchingTrain = oldTrains.find(
+        setTrains(() => {
+          const matchingTrain = initialTrains.find(
             train => train.trainNumber === updatedTrain.trainNumber
           )
 
           if (matchingTrain === undefined) {
-            return oldTrains
+            return initialTrains
           }
 
           const newTrains = getNewTrains(
-            oldTrains,
+            initialTrains,
             updatedTrain,
             stationShortCode,
             stations,
@@ -69,7 +69,7 @@ export const useLiveTrainsSubscription = ({
       client.close()
       client.trains.return()
     }
-  }, [client, stationShortCode, stations, type])
+  }, [client, stationShortCode, stations, type, initialTrains])
 
   return [trains, setTrains]
 }

--- a/site/src/lib/digitraffic/hooks/use_single_train_subscription.ts
+++ b/site/src/lib/digitraffic/hooks/use_single_train_subscription.ts
@@ -42,7 +42,11 @@ export const useSingleTrainSubscription: UseSingleTrainSubscription = ({
   const enabled = 'enabled' in rest ? rest.enabled : true
 
   const clientQuery = useQuery<TrainsMqttClient | undefined>(
-    [TRAINS_CLIENT_QUERY_KEY],
+    [
+      TRAINS_CLIENT_QUERY_KEY,
+      initialTrain?.departureDate,
+      initialTrain?.trainNumber
+    ],
     async () => {
       if (!initialTrain) {
         const invalidParameters = new TypeError(

--- a/site/src/lib/digitraffic/hooks/use_single_train_subscription.ts
+++ b/site/src/lib/digitraffic/hooks/use_single_train_subscription.ts
@@ -60,7 +60,7 @@ export const useSingleTrainSubscription: UseSingleTrainSubscription = ({
 
       return subscribeToTrains({ departureDate, trainNumber })
     },
-    { enabled }
+    { enabled, cacheTime: 0, staleTime: Infinity }
   )
 
   React.useMemo(() => {
@@ -81,11 +81,6 @@ export const useSingleTrainSubscription: UseSingleTrainSubscription = ({
         setTrain(updatedTrain)
       }
     })()
-
-    return function cleanup() {
-      client.close()
-      client.trains.return()
-    }
   }, [
     clientQuery.error,
     clientQuery.isFetching,
@@ -93,6 +88,15 @@ export const useSingleTrainSubscription: UseSingleTrainSubscription = ({
     train,
     initialTrain
   ])
+
+  React.useEffect(() => {
+    if (clientQuery.data) {
+      return function cleanup() {
+        clientQuery.data?.close()
+        clientQuery.data?.trains.return()
+      }
+    }
+  }, [clientQuery])
 
   return [train, error]
 }

--- a/site/src/lib/react_query.ts
+++ b/site/src/lib/react_query.ts
@@ -1,6 +1,23 @@
+import { DigitrafficError } from '@junat/digitraffic'
+import { QueryClient } from '@tanstack/react-query'
+
 /**
  * Get the first erroneus query from a list of queries, in ascending order, if any.
  */
 export const getErrorQuery = <T extends { isError: boolean }>(queries: T[]) => {
   return queries.find(query => query.isError)
 }
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: (failureCount, error) => {
+        if (error instanceof DigitrafficError && !error.isNetworkError) {
+          return false
+        }
+
+        return failureCount !== 2
+      }
+    }
+  }
+})

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -1,21 +1,21 @@
-import type { AppProps as NextAppProps } from 'next/app'
 import type { LayoutProps } from '@typings/layout_props'
+import type { AppProps as NextAppProps } from 'next/app'
 import type { ReactNode } from 'react'
 
-import { useRouter } from 'next/router'
+import { QueryClientProvider } from '@tanstack/react-query'
 import dynamic from 'next/dynamic'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useRouter } from 'next/router'
 
-import constants from '~/constants'
-import { getLocale } from '@utils/get_locale'
 import { useWakeLock } from '@hooks/use_wake_lock'
+import { getLocale } from '@utils/get_locale'
 import translate from '@utils/translate'
+import constants from '~/constants'
 
 const NoScript = dynamic(() => import('~/components/no_script'))
 
-import '~/styles/reset.css'
+import { queryClient } from '~/lib/react_query'
 import '~/styles/global.css'
-import { DigitrafficError } from '@junat/digitraffic'
+import '~/styles/reset.css'
 
 interface AppProps extends NextAppProps {
   Component: NextAppProps['Component'] & {
@@ -71,20 +71,6 @@ interface AppProviderProps {
 }
 
 function AppProvider({ children }: AppProviderProps) {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: (failureCount, error) => {
-          if (error instanceof DigitrafficError && !error.isNetworkError) {
-            return false
-          }
-
-          return failureCount !== 2
-        }
-      }
-    }
-  })
-
   return (
     <QueryClientProvider client={queryClient}>
       <DialogProvider>

--- a/site/src/utils/train.ts
+++ b/site/src/utils/train.ts
@@ -224,7 +224,7 @@ export const getNewTrains = (
     ) {
       const t = simplifyTrain(updatedTrain, stationShortCode, stations)
 
-      return { t, ...train }
+      return { ...train, ...t }
     }
 
     return train


### PR DESCRIPTION
Fixes a pleothra of MQTT related bugs, previously:
- multiple MQTT clients could be created for train pages
- mqtt client would only update the initial fetched trains, 20 or less (or default to an empty array = updating no trains) 
- `useLiveTrainsSubscription` was the source of truth for trains and on the above case could return an empty array of trains because of a race condition (can we connect to MQTT before we fetch initial trains?)
- `useLiveTrainsSubscription` would only create a subscription for a single station
- focusing the window would create a new MQTT connection

These fixes were tested manually. These changes will introduce a hard to reach bug where the user can create multiple MQTT connections by navigating back and forth pages and stay on each page for < 500ms, caused by logic for clearing MQTT connections not being kicked in. Wont have effect on functionality (besides performance) so will merge anyway.