### PR TITLE
fix: how eslint-config-junat.live is specified

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,11 @@
       // Ignore 0.x as these packages may contain breaking changes (https://semver.org/#spec-item-4)
       matchCurrentVersion: '!/^0/',
       groupName: 'minor and patch dependencies'
+    },
+    {
+      matchPackagePatterns: ['^@sentry'],
+      rangeStrategy: 'pin',
+      groupName: 'Sentry dependencies'
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,9 +10,6 @@
       matchUpdateTypes: ['minor', 'patch'],
       // Ignore 0.x as these packages may contain breaking changes (https://semver.org/#spec-item-4)
       matchCurrentVersion: '!/^0/',
-      // If the full e2e suite and unit tests pass, the minor updates probably do not break anything and can be merged without manual testing.
-      // This should be the presumption, but oftentimes breaking changes are introduced to types or unsupported patterns (ie. library internals), alas automatic testing.
-      automerge: true,
       groupName: 'minor and patch dependencies'
     }
   ]

--- a/packages/digitraffic-mqtt/package.json
+++ b/packages/digitraffic-mqtt/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@junat/prettier": "workspace:*",
     "aedes": "^0.50.0",
-    "eslint-config-junat.live": "^0.0.1",
+    "eslint-config-junat.live": "workspace:*",
     "rimraf": "^4.1.2",
     "typescript": "^4.9.4",
     "vite": "^4.4.9",

--- a/packages/digitraffic/tests/base/create_fetch.test.ts
+++ b/packages/digitraffic/tests/base/create_fetch.test.ts
@@ -45,7 +45,6 @@ it('can abort while fetching', async () => {
 
   await Promise.race([fetch('/'), Promise.resolve(controller.abort())]).then(
     () => {
-      expect(request).toBeDefined()
       expect(fetch).toHaveBeenCalled()
     }
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         specifier: ^0.50.0
         version: 0.50.0
       eslint-config-junat.live:
-        specifier: ^0.0.1
+        specifier: workspace:*
         version: link:../eslint-config-junat.live
       rimraf:
         specifier: ^4.1.2


### PR DESCRIPTION
Using a version caused a lookup to npm which, although it did not break anything, is a security risk as we do not currently own the namespace.