### PR TITLE
feat: nearby stations

### DIFF
--- a/site/src/features/geolocation/components/nearby_stations.tsx
+++ b/site/src/features/geolocation/components/nearby_stations.tsx
@@ -15,6 +15,9 @@ import { NotificationPortal } from '~/features/notification-portal'
 import { getPrettifiedAccuracy } from '../utils/accuracy'
 import { getLocale } from '~/utils/get_locale'
 
+import translate from '~/utils/translate'
+import interpolateString from '~/utils/interpolate_string'
+
 type NearbyStationsProps = {
   stations: LocalizedStation[]
   omitStation?: string
@@ -29,6 +32,8 @@ export const NearbyStations = (props: NearbyStationsProps) => {
   const locale = getLocale(router.locale)
 
   const { latestPosition } = useGeolocation({ locale, setStations: () => null })
+
+  const t = translate(locale)
 
   const handleClose = () => {
     setClosedByUser(true)
@@ -87,7 +92,7 @@ export const NearbyStations = (props: NearbyStationsProps) => {
             className="h-full bg-primary-600 text-primary-200 px-[30px] mb-2  flex justify-between"
           >
             <button onClick={() => setOpen(true)} className="cursor-pointer">
-              Wrong station? Change here.
+              {t('otherStationsNotificationTitle')}
             </button>
             <button
               onClick={handleClose}
@@ -98,13 +103,15 @@ export const NearbyStations = (props: NearbyStationsProps) => {
           </motion.div>
           <DialogProvider open={open} onOpenChange={setOpen}>
             <Dialog
-              title="Relevant stations"
+              title={t('relevantStations')}
               description={
                 <span>
-                  Other stations near your location. Your position accuracy for
-                  the latest query was{' '}
-                  {getPrettifiedAccuracy(latestPosition.coords.accuracy)} and
-                  may have affected which station you got navigated to.
+                  {interpolateString(t('$stationsNearYou'), {
+                    accuracy: getPrettifiedAccuracy(
+                      latestPosition.coords.accuracy,
+                      locale
+                    )
+                  })}
                 </span>
               }
             >

--- a/site/src/features/geolocation/components/nearby_stations.tsx
+++ b/site/src/features/geolocation/components/nearby_stations.tsx
@@ -1,0 +1,116 @@
+import type { Locale } from '~/types/common'
+
+import { getStationPath, type LocalizedStation } from '~/lib/digitraffic'
+
+import { AnimatePresence, motion } from 'framer-motion'
+import React from 'react'
+
+import { Dialog, DialogProvider } from '~/components/dialog'
+import Close from '~/components/icons/close.svg'
+import { PrimaryButton } from '~/components/primary_button'
+
+import { useRouter } from 'next/router'
+import { getNearbyStations, useGeolocation } from '~/features/geolocation'
+import { NotificationPortal } from '~/features/notification-portal'
+
+type NearbyStationsProps = {
+  stations: LocalizedStation[]
+  omitStation?: string
+}
+
+export const NearbyStations = (props: NearbyStationsProps) => {
+  const { stations, omitStation } = props
+  const [nearbyStationsCount, setNearbyStationsCount] = React.useState(5)
+  const [open, setOpen] = React.useState(false)
+  const [closedByUser, setClosedByUser] = React.useState(false)
+  const { locale } = useRouter()
+
+  const { latestPosition } = useGeolocation({
+    locale: 'en',
+    setStations: () => null
+  })
+
+  if (!latestPosition) {
+    return null
+  }
+
+  const nearbyStations = [
+    getNearbyStations(latestPosition, {
+      stations,
+      ignorePoorAccuracy: true
+    })
+  ].flat()
+
+  const renderedStations = nearbyStations
+    .filter(nearby => {
+      if (nearby.stationShortCode === omitStation) {
+        return false
+      }
+
+      if ('passengerTraffic' in nearby) {
+        return nearby.passengerTraffic
+      }
+
+      return true
+    })
+    .slice(0, nearbyStationsCount)
+
+
+  return (
+    <AnimatePresence>
+      {renderedStations.length > 0 && !closedByUser ? (
+        <NotificationPortal>
+          <motion.div
+            initial={{ translateY: -20, opacity: 0 }}
+            animate={{ translateY: 0, opacity: 1 }}
+            exit={{ opacity: 0, translateY: -20 }}
+            className="h-full bg-primary-600 text-primary-200 px-[30px] mb-2  flex justify-between"
+          >
+            <button onClick={() => setOpen(true)} className='cursor-pointer'>
+              Wrong station? Change here.
+            </button>
+            <button
+              onClick={() => setClosedByUser(true)}
+              className="flex items-center fill-gray-800 cursor-pointer"
+            >
+              <Close />
+            </button>
+          </motion.div>
+          <DialogProvider open={open} onOpenChange={setOpen}>
+            <Dialog
+              title="Relevant stations"
+              description={
+                <span>
+                  Other stations near your location. Your position accuracy for
+                  the latest query was {latestPosition.coords.accuracy} meters
+                  and may have affected which station you got navigated to.
+                </span>
+              }
+            >
+              <div className="flex flex-col items-start">
+                <div className="flex-1 flex flex-col gap-1">
+                  {renderedStations.map(station => (
+                    <a
+                      key={station.stationShortCode}
+                      href={getStationPath(
+                        station.stationName[locale as Locale]
+                      )}
+                    >
+                      {station.stationName[locale as Locale]}
+                    </a>
+                  ))}
+                </div>
+                <PrimaryButton
+                  className="self-end"
+                  onClick={() => setNearbyStationsCount(current => current + 5)}
+                >
+                  Load more
+                </PrimaryButton>
+              </div>
+            </Dialog>
+          </DialogProvider>
+        </NotificationPortal>
+      ) : null}
+    </AnimatePresence>
+  )
+}

--- a/site/src/features/geolocation/components/nearby_stations.tsx
+++ b/site/src/features/geolocation/components/nearby_stations.tsx
@@ -12,6 +12,7 @@ import { PrimaryButton } from '~/components/primary_button'
 import { useRouter } from 'next/router'
 import { getNearbyStations, useGeolocation } from '~/features/geolocation'
 import { NotificationPortal } from '~/features/notification-portal'
+import { getPrettifiedAccuracy } from '../utils/accuracy'
 
 type NearbyStationsProps = {
   stations: LocalizedStation[]
@@ -55,7 +56,6 @@ export const NearbyStations = (props: NearbyStationsProps) => {
     })
     .slice(0, nearbyStationsCount)
 
-
   return (
     <AnimatePresence>
       {renderedStations.length > 0 && !closedByUser ? (
@@ -66,7 +66,7 @@ export const NearbyStations = (props: NearbyStationsProps) => {
             exit={{ opacity: 0, translateY: -20 }}
             className="h-full bg-primary-600 text-primary-200 px-[30px] mb-2  flex justify-between"
           >
-            <button onClick={() => setOpen(true)} className='cursor-pointer'>
+            <button onClick={() => setOpen(true)} className="cursor-pointer">
               Wrong station? Change here.
             </button>
             <button
@@ -82,8 +82,9 @@ export const NearbyStations = (props: NearbyStationsProps) => {
               description={
                 <span>
                   Other stations near your location. Your position accuracy for
-                  the latest query was {latestPosition.coords.accuracy} meters
-                  and may have affected which station you got navigated to.
+                  the latest query was{' '}
+                  {getPrettifiedAccuracy(latestPosition.coords.accuracy)} and
+                  may have affected which station you got navigated to.
                 </span>
               }
             >

--- a/site/src/features/geolocation/components/nearby_stations.tsx
+++ b/site/src/features/geolocation/components/nearby_stations.tsx
@@ -39,7 +39,12 @@ export const NearbyStations = (props: NearbyStationsProps) => {
     ) {
       const { searchParams } = new URL(window.location.toString())
       searchParams.delete('geolocation')
-      const search = searchParams.size === 0 ? '' : `?${searchParams}`
+
+      // TODO: remove type casting when updating Typescript version (see open issue https://togithub.com/microsoft/TypeScript/issues/54466)
+      const search =
+        (searchParams as URLSearchParams & { size: number }).size === 0
+          ? ''
+          : `?${searchParams}`
       const urlWithoutGeolocation = `${window.location.pathname}${search}`
 
       router.replace(urlWithoutGeolocation, undefined, { shallow: true })

--- a/site/src/features/geolocation/hooks/use_geolocation.ts
+++ b/site/src/features/geolocation/hooks/use_geolocation.ts
@@ -12,8 +12,6 @@ import { useToast } from '@features/toast'
 import { getNearbyStations } from '../utils/get_nearby_stations'
 import translate from '@utils/translate'
 
-import { headers } from 'next/headers'
-
 type Translations = {
   geolocationPositionUnavailableError: string
   geolocationPositionTimeoutError: string

--- a/site/src/features/geolocation/hooks/use_geolocation.ts
+++ b/site/src/features/geolocation/hooks/use_geolocation.ts
@@ -9,8 +9,8 @@ import { getStationPath } from '~/lib/digitraffic'
 
 import { useToast } from '@features/toast'
 
-import { getNearbyStations } from '../utils/get_nearby_stations'
 import translate from '@utils/translate'
+import { getNearbyStations } from '../utils/get_nearby_stations'
 
 type Translations = {
   geolocationPositionUnavailableError: string

--- a/site/src/features/geolocation/hooks/use_geolocation.ts
+++ b/site/src/features/geolocation/hooks/use_geolocation.ts
@@ -12,6 +12,8 @@ import { useToast } from '@features/toast'
 import { getNearbyStations } from '../utils/get_nearby_stations'
 import translate from '@utils/translate'
 
+import { headers } from 'next/headers'
+
 type Translations = {
   geolocationPositionUnavailableError: string
   geolocationPositionTimeoutError: string
@@ -62,6 +64,7 @@ export const useGeolocation = ({
 }: UseGeolocationProps) => {
   const t = translate(locale)
   const router = useRouter()
+
   const toast = useToast(state => state.toast)
 
   const getCurrentPosition = React.useCallback(() => {
@@ -136,8 +139,12 @@ export function handlePosition<T extends StationParams>(
       toast(translations.badGeolocationAccuracy)
     } else {
       latestPosition = position
+      const url = new URL(
+        getStationPath(station.stationName[locale]) + `?geolocation=true`,
+        window.origin
+      )
 
-      router.push(getStationPath(station.stationName[locale]))
+      router.push(url.toString())
     }
   }
 

--- a/site/src/features/geolocation/tests/hooks/use_geolocation.test.tsx
+++ b/site/src/features/geolocation/tests/hooks/use_geolocation.test.tsx
@@ -81,9 +81,7 @@ it('pushes a new route if accuracy is sufficient', () => {
   handlePosition(props)
 
   expect(getCurrentPosition).toHaveBeenCalledOnce()
-  expect(push).toHaveBeenCalledWith(
-    props.stations![0].stationName[props.locale]
-  )
+  expect(push).toHaveBeenCalledOnce()
 })
 
 it('works without stations', () => {

--- a/site/src/features/geolocation/tests/hooks/use_geolocation.test.tsx
+++ b/site/src/features/geolocation/tests/hooks/use_geolocation.test.tsx
@@ -144,7 +144,7 @@ describe('hook', () => {
       wrapper: WRAPPER
     })
 
-    expect(Object.keys(result.current)).toStrictEqual(['getCurrentPosition'])
+    expect(Object.keys(result.current)).contain('getCurrentPosition')
   })
 
   it('calls get current position when invoked', () => {

--- a/site/src/features/geolocation/tests/nearby_stations.test.ts
+++ b/site/src/features/geolocation/tests/nearby_stations.test.ts
@@ -1,0 +1,20 @@
+import { getPrettifiedAccuracy } from '../utils/accuracy'
+
+import { it, expect } from 'vitest'
+
+it('returns accuracy in meters when accuracy is less than 1000', () => {
+  expect(getPrettifiedAccuracy(35)).toStrictEqual('35 meters')
+})
+
+it('returns truncated accuracy when accuracy is less than 1000 and accuracy has decimal points', () => {
+  expect(getPrettifiedAccuracy(121.212)).toStrictEqual('121 meters')
+})
+
+it('returns accuracy in kilometers when accuracy is greater than or equal to 1000 meters', () => {
+  expect(getPrettifiedAccuracy(1000)).toStrictEqual('1 kilometer')
+  expect(getPrettifiedAccuracy(2002)).toStrictEqual('2 kilometers')
+})
+
+it('returns accuracy in metre (singular) if truncated accuracy is equal to 1', () => {
+  expect(getPrettifiedAccuracy(1.5)).toStrictEqual('1 metre')
+})

--- a/site/src/features/geolocation/tests/nearby_stations.test.ts
+++ b/site/src/features/geolocation/tests/nearby_stations.test.ts
@@ -3,18 +3,26 @@ import { getPrettifiedAccuracy } from '../utils/accuracy'
 import { it, expect } from 'vitest'
 
 it('returns accuracy in meters when accuracy is less than 1000', () => {
-  expect(getPrettifiedAccuracy(35)).toStrictEqual('35 metres')
+  expect(getPrettifiedAccuracy(35, 'en')).toStrictEqual('35 metres')
 })
 
 it('returns truncated accuracy when accuracy is less than 1000 and accuracy has decimal points', () => {
-  expect(getPrettifiedAccuracy(121.212)).toStrictEqual('121 metres')
+  expect(getPrettifiedAccuracy(121.212, 'en')).toStrictEqual('121 metres')
 })
 
 it('returns accuracy in kilometers when accuracy is greater than or equal to 1000 meters', () => {
-  expect(getPrettifiedAccuracy(1000)).toStrictEqual('1 kilometres')
-  expect(getPrettifiedAccuracy(2002)).toStrictEqual('2 kilometres')
+  expect(getPrettifiedAccuracy(1000, 'en')).toStrictEqual('1 kilometre')
+  expect(getPrettifiedAccuracy(2002, 'en')).toStrictEqual('2 kilometres')
 })
 
 it('returns accuracy in metre (singular) if truncated accuracy is equal to 1', () => {
-  expect(getPrettifiedAccuracy(1.5)).toStrictEqual('1 metre')
+  expect(getPrettifiedAccuracy(1.5, 'en')).toStrictEqual('1 metre')
+})
+
+it('returns en meter when accuracy is equal to one and locale is swedish', () => {
+  expect(getPrettifiedAccuracy(1, 'sv')).toStrictEqual('en meter')
+})
+
+it('returns en kilometer when accuracy is equal to one and locale is swedish', () => {
+  expect(getPrettifiedAccuracy(1000, 'sv')).toStrictEqual('en kilometer')
 })

--- a/site/src/features/geolocation/tests/nearby_stations.test.ts
+++ b/site/src/features/geolocation/tests/nearby_stations.test.ts
@@ -3,16 +3,16 @@ import { getPrettifiedAccuracy } from '../utils/accuracy'
 import { it, expect } from 'vitest'
 
 it('returns accuracy in meters when accuracy is less than 1000', () => {
-  expect(getPrettifiedAccuracy(35)).toStrictEqual('35 meters')
+  expect(getPrettifiedAccuracy(35)).toStrictEqual('35 metres')
 })
 
 it('returns truncated accuracy when accuracy is less than 1000 and accuracy has decimal points', () => {
-  expect(getPrettifiedAccuracy(121.212)).toStrictEqual('121 meters')
+  expect(getPrettifiedAccuracy(121.212)).toStrictEqual('121 metres')
 })
 
 it('returns accuracy in kilometers when accuracy is greater than or equal to 1000 meters', () => {
-  expect(getPrettifiedAccuracy(1000)).toStrictEqual('1 kilometer')
-  expect(getPrettifiedAccuracy(2002)).toStrictEqual('2 kilometers')
+  expect(getPrettifiedAccuracy(1000)).toStrictEqual('1 kilometres')
+  expect(getPrettifiedAccuracy(2002)).toStrictEqual('2 kilometres')
 })
 
 it('returns accuracy in metre (singular) if truncated accuracy is equal to 1', () => {

--- a/site/src/features/geolocation/utils/accuracy.ts
+++ b/site/src/features/geolocation/utils/accuracy.ts
@@ -1,17 +1,30 @@
+import type { Locale } from '@typings/common'
+
+import translate from '~/utils/translate'
+
 /**
- * @returns Truncated accuracy with an unit, one of meters or kilometers.
+ * @returns Truncated accuracy with an unit, one of meters or kilometers. Special case 'sv' where 1 metre is just en metre same for kilometre.
  */
-export const getPrettifiedAccuracy = (accuracy: number): string => {
-  let [meters, kilometers] = ['metres', 'kilometres']
+export const getPrettifiedAccuracy = (
+  accuracy: number,
+  locale: Locale
+): string => {
+  const t = translate(locale)
+  let [meters, kilometers] = [
+    `${Math.trunc(accuracy)} ${t('metres')}`,
+    `${Math.trunc(accuracy / 1000)} ${t('kilometres')}`
+  ]
 
   if (Math.trunc(accuracy) === 1) {
-    meters = 'metre'
+    meters =
+      locale === 'sv' ? t('metre') : `${Math.trunc(accuracy)} ${t('metre')}`
   }
   if (Math.trunc(accuracy / 1000) === 1) {
-    kilometers = 'kilometres'
+    kilometers =
+      locale === 'sv'
+        ? t('kilometre')
+        : `${Math.trunc(accuracy / 1000)} ${t('kilometre')}`
   }
 
-  return accuracy < 1000
-    ? `${Math.trunc(accuracy)} ${meters}`
-    : `${Math.trunc(accuracy / 1000)} ${kilometers}`
+  return accuracy < 1000 ? meters : kilometers
 }

--- a/site/src/features/geolocation/utils/accuracy.ts
+++ b/site/src/features/geolocation/utils/accuracy.ts
@@ -2,13 +2,13 @@
  * @returns Truncated accuracy with an unit, one of meters or kilometers.
  */
 export const getPrettifiedAccuracy = (accuracy: number): string => {
-  let [meters, kilometers] = ['meters', 'kilometers']
+  let [meters, kilometers] = ['metres', 'kilometres']
 
   if (Math.trunc(accuracy) === 1) {
-    meters = 'meter'
+    meters = 'metre'
   }
   if (Math.trunc(accuracy / 1000) === 1) {
-    kilometers = 'kilometer'
+    kilometers = 'kilometres'
   }
 
   return accuracy < 1000

--- a/site/src/features/geolocation/utils/accuracy.ts
+++ b/site/src/features/geolocation/utils/accuracy.ts
@@ -1,0 +1,17 @@
+/**
+ * @returns Truncated accuracy with an unit, one of meters or kilometers.
+ */
+export const getPrettifiedAccuracy = (accuracy: number): string => {
+  let [meters, kilometers] = ['meters', 'kilometers']
+
+  if (Math.trunc(accuracy) === 1) {
+    meters = 'meter'
+  }
+  if (Math.trunc(accuracy / 1000) === 1) {
+    kilometers = 'kilometer'
+  }
+
+  return accuracy < 1000
+    ? `${Math.trunc(accuracy)} ${meters}`
+    : `${Math.trunc(accuracy / 1000)} ${kilometers}`
+}

--- a/site/src/features/geolocation/utils/get_nearby_stations.ts
+++ b/site/src/features/geolocation/utils/get_nearby_stations.ts
@@ -7,15 +7,17 @@ interface GetNearbyStationsProps {
   /**
    * If position data was accurate to 1000 meters return the nearest station.
    * Otherwise return stations sorted by their distance to `position`.
+   * Use `ignorePoorAccuracy` parameter to disable this behavior and always return an array.
    */
   <T extends { latitude: number; longitude: number }>(
     position: GeolocationPosition,
-    opts: { stations: T[] }
+    opts: { stations: T[]; ignorePoorAccuracy?: boolean }
   ): T | T[]
   <T extends { latitude: number; longitude: number }>(
     position: GeolocationPosition,
     opts: {
       stations: T[]
+      ignorePoorAccuracy?: boolean
       locale: Locale
     }
   ): T | T[]
@@ -35,7 +37,9 @@ export const getNearbyStations: GetNearbyStationsProps = (position, opts) => {
     position
   )
 
-  const poorAccuracy = position.coords.accuracy > 1000
+  const poorAccuracy = opts.ignorePoorAccuracy
+    ? true
+    : position.coords.accuracy > 1000
 
   if (poorAccuracy) {
     return sortStationsByDistance<(typeof opts.stations)[number]>(

--- a/site/src/features/notification-portal/index.tsx
+++ b/site/src/features/notification-portal/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { createPortal } from 'react-dom'
+
+type NotificationPortalProps = {
+  children: React.ReactNode | React.ReactNode[]
+}
+
+const missingElementExpection = () => {
+  throw new TypeError(
+    'required element with data attribute [data-notification-slot] does not exist'
+  )
+}
+
+/**
+ * Portal component(s) into notification slot
+ */
+export const NotificationPortal = (props: NotificationPortalProps) => {
+  return createPortal(
+    props.children,
+    document.querySelector('[data-notification-slot="true"]') ||
+      missingElementExpection(),
+    'notification'
+  )
+}

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -35,6 +35,7 @@ import { From, To } from 'frominto'
 import { ErrorMessageWithRetry } from '~/components/error_message'
 import { StationDropdownMenu } from '~/components/station_dropdown_menu'
 import { useFilters } from '~/hooks/use_filters'
+import { NearbyStations } from '~/features/geolocation/components/nearby_stations'
 
 export type StationProps = {
   station: LocalizedStation
@@ -124,6 +125,8 @@ export function Station({ station, locale }: StationProps) {
             long={station.longitude}
           />
         </div>
+
+        <NearbyStations stations={stations} omitStation={station.stationShortCode} />
 
         {errorQuery !== undefined && (
           <ErrorMessageWithRetry

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -45,6 +45,10 @@ export type StationProps = {
 export function Station({ station, locale }: StationProps) {
   const timetableRowId = useTimetableRow(state => state.timetableRowId)
 
+  const geolocationTriggeredNavigation =
+    typeof window !== 'undefined' &&
+    /geolocation=true/.test(window.location.search)
+
   const router = useRouter()
   const [count, setCount, setCurrentShortCode] = useStationPage(
     state => [
@@ -126,7 +130,12 @@ export function Station({ station, locale }: StationProps) {
           />
         </div>
 
-        <NearbyStations stations={stations} omitStation={station.stationShortCode} />
+        {geolocationTriggeredNavigation && (
+          <NearbyStations
+            stations={stations}
+            omitStation={station.stationShortCode}
+          />
+        )}
 
         {errorQuery !== undefined && (
           <ErrorMessageWithRetry

--- a/site/src/layouts/page.tsx
+++ b/site/src/layouts/page.tsx
@@ -14,8 +14,13 @@ export default function Page({ children }: LayoutProps) {
   const { data: stations = [] } = useStations()
 
   return (
-    <div className="pt-[1.875rem] m-auto w-[100%]">
-      <div className="px-[1.875rem] max-w-[500px] m-auto min-h-screen">
+    <div>
+      <div
+        data-notification-slot
+        className="h-[1.875rem] w-full [&:not:empty]:bg-primary-600 text-primary-200"
+        aria-live="polite"
+      />
+      <div className="mt-2 px-[1.875rem] max-w-[500px] m-auto min-h-screen">
         {children}
       </div>
       <Footer router={router} stations={stations} />

--- a/site/src/locales/en.json
+++ b/site/src/locales/en.json
@@ -96,6 +96,11 @@
   "relevantStations": "Relevant stations",
   "$stationsNearYou": "Other stations near your location. Your position accuracy for the latest query was {{ accuracy }} and may have affected which station you got navigated to.",
 
+  "metre": "metre",
+  "metres": "metres",
+  "kilometre": "kilometre",
+  "kilometres": "kilometres",
+
   "stationOptions": "Station options",
   "addStationToFavorites": "Add to favorites",
   "removeStationFromFavorites": "Remove from favorites",

--- a/site/src/locales/en.json
+++ b/site/src/locales/en.json
@@ -92,6 +92,10 @@
     "additionalLocomotive": "Additional locomotive"
   },
 
+  "otherStationsNotificationTitle": "View other stations near you",
+  "relevantStations": "Relevant stations",
+  "$stationsNearYou": "Other stations near your location. Your position accuracy for the latest query was {{ accuracy }} and may have affected which station you got navigated to.",
+
   "stationOptions": "Station options",
   "addStationToFavorites": "Add to favorites",
   "removeStationFromFavorites": "Remove from favorites",

--- a/site/src/locales/fi.json
+++ b/site/src/locales/fi.json
@@ -96,6 +96,11 @@
   "relevantStations": "Sinua lähellä olevat asemat",
   "$stationsNearYou": "Muut asemat lähellä sijaintiasi. Sijainnin tarkkuus oli {{ accuracy }} ja vaikutti mihin sinut navigoitiin.",
 
+  "metre": "metri",
+  "metres": "metriä",
+  "kilometre": "kilometri",
+  "kilometres": "kilometriä",
+
   "stationOptions": "Aseman vaihtoehdot",
   "addStationToFavorites": "Lisää asema suosikiksi",
   "removeStationFromFavorites": "Poista asema suosikeista",

--- a/site/src/locales/fi.json
+++ b/site/src/locales/fi.json
@@ -92,6 +92,10 @@
     "additionalLocomotive": "Vaihtotyö veturina"
   },
 
+  "otherStationsNotificationTitle": "Näytä muut läheiset asemat",
+  "relevantStations": "Sinua lähellä olevat asemat",
+  "$stationsNearYou": "Muut asemat lähellä sijaintiasi. Sijainnin tarkkuus oli {{ accuracy }} ja vaikutti mihin sinut navigoitiin.",
+
   "stationOptions": "Aseman vaihtoehdot",
   "addStationToFavorites": "Lisää asema suosikiksi",
   "removeStationFromFavorites": "Poista asema suosikeista",

--- a/site/src/locales/sv.json
+++ b/site/src/locales/sv.json
@@ -92,6 +92,10 @@
     "additionalLocomotive": "Additional locomotive"
   },
 
+  "otherStationsNotificationTitle": "Visa andra närliggande stationer",
+  "relevantStations": "Relevanta stationer",
+  "$stationsNearYou": "Andra stationer nära din plats. Din positionsnoggrannhet var {{ accuracy }} och kan ha påverkat vilken station du navigerade till.",
+
   "stationOptions": "Stationsalternativ",
   "addStationToFavorites": "Lägg till i favoriter",
   "removeStationFromFavorites": "Ta bort från favoriter",

--- a/site/src/locales/sv.json
+++ b/site/src/locales/sv.json
@@ -96,6 +96,11 @@
   "relevantStations": "Relevanta stationer",
   "$stationsNearYou": "Andra stationer nära din plats. Din positionsnoggrannhet var {{ accuracy }} och kan ha påverkat vilken station du navigerade till.",
 
+  "metre": "en meter",
+  "metres": "meter",
+  "kilometre": "en kilometer",
+  "kilometres": "kilometer",
+
   "stationOptions": "Stationsalternativ",
   "addStationToFavorites": "Lägg till i favoriter",
   "removeStationFromFavorites": "Ta bort från favoriter",


### PR DESCRIPTION
https://github.com/jqpe/junat.live/assets/65775308/b88b44e0-e5d8-4da4-8df8-f9431bcbe1e9

According to user feedback geolocation button would sometimes navigate to undesired stations. For example, when in Tripla the geolocation would assume Pasila car-carrier station, but the user would like to see trains for Pasila. This feature makes the geolocation more forgiving. It also addresses an edge case where a user might be in-between two stations and assuming one over the other based on distance is stupid. Moreover, sometimes a user used the geolocation feature in Helsinki and was put in Pasila due to bad geolocation conditions. Things that affect are battery life, GPS signal strength (ie. rocks), whether the user is connected to a WI-FI network, or if the position was served from cache. 