### PR TITLE
fix: use create from zustand/traditional

### DIFF
--- a/site/src/features/toast/stores/toast.ts
+++ b/site/src/features/toast/stores/toast.ts
@@ -1,7 +1,7 @@
 import type { StoreApi, UseBoundStore } from 'zustand'
 import type { ReactNode } from 'react'
 
-import {create} from 'zustand'
+import { createWithEqualityFn } from 'zustand/traditional'
 
 interface Toast {
   title: ReactNode
@@ -24,7 +24,7 @@ export interface Store {
   readonly current?: Toast
 }
 
-export const useToast: UseBoundStore<StoreApi<Store>> = create<Store>(
+export const useToast: UseBoundStore<StoreApi<Store>> = createWithEqualityFn<Store>(
   (set, get) => ({
     current: undefined,
     _controller: new AbortController(),

--- a/site/src/hooks/use_favorites.ts
+++ b/site/src/hooks/use_favorites.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createWithEqualityFn } from 'zustand/traditional'
 import { persist } from 'zustand/middleware'
 
 interface FavoritesStore {
@@ -13,7 +13,7 @@ type StationShortCode = string
 /**
  * Hook to interface with favorite stations stored in local storage. Station shortcodes are stored.
  */
-export const useFavorites = create<FavoritesStore>()(
+export const useFavorites = createWithEqualityFn<FavoritesStore>()(
   persist(
     (set, get) => ({
       favorites: <string[]>[],

--- a/site/src/hooks/use_filters.ts
+++ b/site/src/hooks/use_filters.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { createWithEqualityFn } from 'zustand/traditional'
 
 interface FiltersStore {
   destination: StationShortCode | null
@@ -12,7 +12,7 @@ type StationShortCode = string
 /**
  * Hook to interface with filters.
  */
-export const useFilters = create<FiltersStore>(set => ({
+export const useFilters = createWithEqualityFn<FiltersStore>(set => ({
   destination: null,
   actions: {
     setDestination(destination) {

--- a/site/src/hooks/use_station_page.ts
+++ b/site/src/hooks/use_station_page.ts
@@ -1,6 +1,6 @@
 import type { StoreApi, UseBoundStore } from 'zustand'
 
-import {create} from 'zustand'
+import {createWithEqualityFn} from 'zustand/traditional'
 
 export interface StationPageStore {
   /**
@@ -20,7 +20,7 @@ interface Store extends StationPageStore {
  * Hook for storing data for multiple stations.
  */
 export const useStationPage: UseBoundStore<StoreApi<StationPageStore>> =
-  create<Store>((set, get) => ({
+  createWithEqualityFn<Store>((set, get) => ({
     stations: {},
     currentShortCode: undefined,
     setCurrentShortCode: (code: string) => {

--- a/site/src/hooks/use_timetable_row.ts
+++ b/site/src/hooks/use_timetable_row.ts
@@ -1,11 +1,11 @@
-import { create } from 'zustand'
+import { createWithEqualityFn } from 'zustand/traditional'
 
 interface TimetableRowStore {
   timetableRowId: string
   setTimetableRowId: (id: string) => void
 }
 
-export const useTimetableRow = create<TimetableRowStore>(set => ({
+export const useTimetableRow = createWithEqualityFn<TimetableRowStore>(set => ({
   timetableRowId: '',
   setTimetableRowId: id => set(() => ({ timetableRowId: id }))
 }))


### PR DESCRIPTION
The `create` method imported from `zustand` was deprecated and moved into `zustand/traditional` with a different name.