### PR TITLE
fix: move train filtering out of query function

### DIFF
--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -84,7 +84,7 @@ export function Station({ station, locale }: StationProps) {
     path: router.asPath
   })
 
-  const trains = train.data ?? []
+  const trains = train.data?.filter(train => train.commercialStop) ?? []
 
   const empty = train.isSuccess && train.data.length === 0
 

--- a/site/src/lib/digitraffic/hooks/use_live_trains.ts
+++ b/site/src/lib/digitraffic/hooks/use_live_trains.ts
@@ -76,7 +76,7 @@ export function useLiveTrains(opts: {
       normalizeTrains(t),
       opts.stationShortCode,
       opts.localizedStations
-    ).filter(train => train.commercialStop)
+    )
   }
 
   return useQuery<SimplifiedTrain[], unknown>({


### PR DESCRIPTION
Doing filtering inside the query function would affect the length of returned data, which in turn is used for display logic. By decoupling logic for what is displayed and what is fetched, having the logic in the same domain makes the code easier to reason about. Moreover, fixes a bug where Digitraffic would return trains that do not stop at a station (although this should not happen). Those trains would be filtered out, and logic for pagination would see less trains returned than requested and asssume no more trains are available.
