### PR TITLE
fix: bigger tap target for train link, accessible label

### DIFF
--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -21,6 +21,8 @@ import {
   getTrainHref
 } from './helpers'
 import { useRestoreScrollPosition } from './hooks'
+import translate from '~/utils/translate'
+import { Code, getTrainType } from '~/utils/train'
 
 type ControlsAnimationDefinition = Parameters<AnimationControls['start']>['0']
 
@@ -182,6 +184,8 @@ export function TimetableRow({
         className={hasLongTrainType ? 'text-[min(2.5vw,80%)]' : undefined}
       >
         <Link
+          aria-label={getTrainLabel(train, locale)}
+          className="w-full text-center"
           href={getTrainHref(locale, train.departureDate, train.trainNumber)}
           onClick={() => setTimetableRowId(timetableRowId)}
         >
@@ -193,3 +197,19 @@ export function TimetableRow({
 }
 
 export default TimetableRow
+
+type GetTrainLabelTrain = {
+  commuterLineID?: string
+  trainType: string
+  trainNumber: number
+}
+
+const getTrainLabel = (train: GetTrainLabelTrain, locale: Locale): string => {
+  if (train.commuterLineID) {
+    return `${train.commuterLineID}-${translate(locale)('train')}`
+  }
+
+  const type = getTrainType(train.trainType as Code, locale)
+
+  return `${type} ${train.trainNumber}`
+}


### PR DESCRIPTION
<img width="760" alt="Screenshot of a link element and web inspector" src="https://github.com/jqpe/junat.live/assets/65775308/419bc7d0-914c-4a7d-a3f2-2e64595c4293">

- fix: Previous tap target would be hard to click since it only took the space of the link content, sometimes resulting in only 9px width.
- fix: add an accessible label to train link. Now reads out: 'R-Train, link' instead of 'R, link' or (eg.) 'InterCity 3939, link' if the train does not have a commuterLineID