### PR TITLE
fix: remove defer attribute from analytics script

### DIFF
--- a/site/src/pages/_document.tsx
+++ b/site/src/pages/_document.tsx
@@ -8,7 +8,6 @@ export default function Document() {
       <Head>
         <script
           async
-          defer
           src="https://analytics.junat.live/script.js"
           data-website-id="d9cc456e-d163-4432-991a-021091149b58"
           // Prevents the tracking script from running on preview environment


### PR DESCRIPTION
- Using both async and defer is not allowed and does not make sense. Deferred scripts load as the DOM parsing is complete, while as async scripts load lazily, but as soon as possible. Use async as recommended by umami documentation
