### PR TITLE
build: update docker and dev command

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -29,7 +29,7 @@ RUN pnpm install -r
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN  \
     --mount=type=secret,id=SENTRY_DSN \  
     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) && \
-    export SENTRY_DSN=$(cat /run/secrets/SENTRY_DSN) && \
+    export NEXT_PUBLIC_SENTRY_DSN=$(cat /run/secrets/SENTRY_DSN) && \
     pnpm dlx turbo run build --filter=site...
 
 FROM base AS runner

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "analyze": "ANALYZE=true next build",
-    "dev": "pnpm graphql-codegen --watch &>/dev/null && next dev",
+    "dev": "next dev",
     "check-types": "tsc --noEmit",
     "gql-codegen": "pnpm graphql-codegen",
     "build": "next build",


### PR DESCRIPTION
- Updated the Dockerfile to export `NEXT_PUBLIC_SENTRY_DSN`, the image build command remains the same:

```sh
SENTRY_AUTH_TOKEN="" SENTRY_DSN="" docker build -f site/Dockerfile --secret id=SENTRY_DSN --secret id=SENTRY_AUTH_TOKEN .
```

- Removed graphql watch command as it was rarely used