### PR TITLE
chore: update react-spring-bottom-sheet to fork

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@headlessui/react':
         specifier: ^2.0.0
         version: 2.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@jqpe/react-spring-bottom-sheet':
+        specifier: 3.4.2
+        version: 3.4.2(@react-three/fiber@8.16.3(react-dom@18.2.0(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react@18.2.0)(three@0.164.1))(@types/react@18.0.27)(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react-konva@18.2.10(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react-zdog@1.2.2)(react@18.2.0)(three@0.164.1)(zdog@1.1.3)
       '@junat/digitraffic':
         specifier: workspace:*
         version: link:../packages/digitraffic/dist
@@ -216,9 +219,6 @@ importers:
       react-remove-scroll:
         specifier: ^2.5.9
         version: 2.5.9(@types/react@18.0.27)(react@18.2.0)
-      react-spring-bottom-sheet:
-        specifier: 3.5.0-alpha.0
-        version: 3.5.0-alpha.0(@react-three/fiber@8.16.3(react-dom@18.2.0(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react@18.2.0)(three@0.164.1))(@types/react@18.0.27)(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react-konva@18.2.10(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react-zdog@1.2.2)(react@18.2.0)(three@0.164.1)(zdog@1.1.3)
       sharp:
         specifier: ^0.33.0
         version: 0.33.3
@@ -2918,6 +2918,11 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jqpe/react-spring-bottom-sheet@3.4.2':
+    resolution: {integrity: sha512-JCs0RuCI95ASkrwk3pCXFXZLml4N6kTbG0FGXXxLBi/iTK/3jqotkxBnhzLhGCM2Zf6f+hViEH8N8MkMDPtEOg==}
+    peerDependencies:
+      react: ^16.14.0 || 17 || 18
+
   '@jridgewell/gen-mapping@0.1.1':
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -3896,8 +3901,8 @@ packages:
       expo-asset: '>=8.4'
       expo-file-system: '>=11.0'
       expo-gl: '>=11.0'
-      react: '>=18.0'
-      react-dom: '>=18.0'
+      react: '>=18.0 || 18.x'
+      react-dom: '>=18.0 || 18.x'
       react-native: '>=0.64'
       three: '>=0.133'
     peerDependenciesMeta:
@@ -3908,6 +3913,8 @@ packages:
       expo-file-system:
         optional: true
       expo-gl:
+        optional: true
+      react:
         optional: true
       react-dom:
         optional: true
@@ -9869,11 +9876,6 @@ packages:
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0
-
-  react-spring-bottom-sheet@3.5.0-alpha.0:
-    resolution: {integrity: sha512-iCuv+qq/2kIHLs75Z/5Tgh9/tc0hklFn/CW6XDX0GA2IKqZP/kYky+/yN1BJCD74dtnL6Dx3p+Seu1ifVnf2xQ==}
-    peerDependencies:
-      react: ^16.14.0 || 17 || 18
 
   react-spring@9.7.3:
     resolution: {integrity: sha512-oTxDpFV5gzq7jQX6+bU0SVq+vX8VnuuT5c8Zwn6CpDErOPvCmV+DRkPiEBtaL3Ozgzwiy5yFx83N0h303j/r3A==}
@@ -15918,6 +15920,29 @@ snapshots:
       '@types/yargs': 17.0.20
       chalk: 4.1.2
 
+  '@jqpe/react-spring-bottom-sheet@3.4.2(@react-three/fiber@8.16.3(react-dom@18.2.0(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react@18.2.0)(three@0.164.1))(@types/react@18.0.27)(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react-konva@18.2.10(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react-zdog@1.2.2)(react@18.2.0)(three@0.164.1)(zdog@1.1.3)':
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      '@reach/portal': 0.13.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@xstate/react': 1.6.3(@types/react@18.0.27)(react@18.2.0)(xstate@4.38.3)
+      body-scroll-lock: 3.1.5
+      focus-trap: 6.9.4
+      react: 18.2.0
+      react-spring: 9.7.3(@react-three/fiber@8.16.3(react-dom@18.2.0(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react@18.2.0)(three@0.164.1))(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react-konva@18.2.10(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react-zdog@1.2.2)(react@18.2.0)(three@0.164.1)(zdog@1.1.3)
+      react-use-gesture: 8.0.1(react@18.2.0)
+      xstate: 4.38.3
+    transitivePeerDependencies:
+      - '@react-three/fiber'
+      - '@types/react'
+      - '@xstate/fsm'
+      - konva
+      - react-dom
+      - react-konva
+      - react-native
+      - react-zdog
+      - three
+      - zdog
+
   '@jridgewell/gen-mapping@0.1.1':
     dependencies:
       '@jridgewell/set-array': 1.1.2
@@ -17195,7 +17220,6 @@ snapshots:
       base64-js: 1.5.1
       buffer: 6.0.3
       its-fine: 1.2.5(react@18.2.0)
-      react: 18.2.0
       react-reconciler: 0.27.0(react@18.2.0)
       react-use-measure: 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       scheduler: 0.21.0
@@ -17203,6 +17227,7 @@ snapshots:
       three: 0.164.1
       zustand: 3.7.2(react@18.2.0)
     optionalDependencies:
+      react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-native: 0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0)
 
@@ -25193,29 +25218,6 @@ snapshots:
       object-assign: 4.1.1
       react: 18.2.0
       react-is: 18.3.1
-
-  react-spring-bottom-sheet@3.5.0-alpha.0(@react-three/fiber@8.16.3(react-dom@18.2.0(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react@18.2.0)(three@0.164.1))(@types/react@18.0.27)(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react-konva@18.2.10(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react-zdog@1.2.2)(react@18.2.0)(three@0.164.1)(zdog@1.1.3):
-    dependencies:
-      '@juggle/resize-observer': 3.4.0
-      '@reach/portal': 0.13.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@xstate/react': 1.6.3(@types/react@18.0.27)(react@18.2.0)(xstate@4.38.3)
-      body-scroll-lock: 3.1.5
-      focus-trap: 6.9.4
-      react: 18.2.0
-      react-spring: 9.7.3(@react-three/fiber@8.16.3(react-dom@18.2.0(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react@18.2.0)(three@0.164.1))(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react-konva@18.2.10(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react-zdog@1.2.2)(react@18.2.0)(three@0.164.1)(zdog@1.1.3)
-      react-use-gesture: 8.0.1(react@18.2.0)
-      xstate: 4.38.3
-    transitivePeerDependencies:
-      - '@react-three/fiber'
-      - '@types/react'
-      - '@xstate/fsm'
-      - konva
-      - react-dom
-      - react-konva
-      - react-native
-      - react-zdog
-      - three
-      - zdog
 
   react-spring@9.7.3(@react-three/fiber@8.16.3(react-dom@18.2.0(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react@18.2.0)(three@0.164.1))(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react-konva@18.2.10(konva@9.3.6)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.0(@babel/core@7.20.12)(@babel/preset-env@7.23.6(@babel/core@7.20.12))(@types/react@18.0.27)(react@18.2.0))(react-zdog@1.2.2)(react@18.2.0)(three@0.164.1)(zdog@1.1.3):
     dependencies:

--- a/site/package.json
+++ b/site/package.json
@@ -43,7 +43,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-remove-scroll": "^2.5.9",
-    "react-spring-bottom-sheet": "3.5.0-alpha.0",
+    "@jqpe/react-spring-bottom-sheet": "3.4.2",
     "sharp": "^0.33.0",
     "yup": "^0.32.11",
     "zustand": "4.4.7"

--- a/site/src/components/bottom_sheet/index.tsx
+++ b/site/src/components/bottom_sheet/index.tsx
@@ -1,3 +1,3 @@
-import 'react-spring-bottom-sheet/dist/style.css'
+import '@jqpe/react-spring-bottom-sheet/dist/style.css'
 
-export { BottomSheet } from 'react-spring-bottom-sheet'
+export { BottomSheet } from '@jqpe/react-spring-bottom-sheet'


### PR DESCRIPTION
Fixes deprecation warnings causing https://junat.sentry.io/share/issue/9f148c8b22524adc89d4545a6d601fce/ and https://junat.sentry.io/share/issue/3682c39b03db42bba32ad010f04237a8/
