### PR TITLE
ci: update deps, cache

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -21,7 +21,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -5,6 +5,9 @@ name: 'Next.js Bundle Analysis'
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:
@@ -54,7 +57,7 @@ jobs:
         run: pnpm build && mv site/.next .next
 
       - name: Analyze bundle
-        run: npx -p nextjs-bundle-analysis report
+        run: pnpm --package nextjs-bundle-analysis dlx report
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4
@@ -70,22 +73,9 @@ jobs:
           branch: ${{ github.event.pull_request.base.ref }}
           path: .next/analyze/base
 
-      # And here's the second place - this runs after we have both the current and
-      # base branch bundle stats, and will compare them to determine what changed.
-      # There are two configurable arguments that come from package.json:
-      #
-      # - budget: optional, set a budget (bytes) against which size changes are measured
-      #           it's set to 350kb here by default, as informed by the following piece:
-      #           https://infrequently.org/2021/03/the-performance-inequality-gap/
-      #
-      # - red-status-percentage: sets the percent size increase where you get a red
-      #                          status indicator, defaults to 20%
-      #
-      # Either of these arguments can be changed or removed by editing the `nextBundleAnalysis`
-      # entry in your package.json file.
       - name: Compare with base branch bundle
         if: success() && github.event.number
-        run: ls -laR .next/analyze/base && npx -p nextjs-bundle-analysis compare
+        run: ls -laR .next/analyze/base && pnpm --package nextjs-bundle-analysis dlx compare
 
       - name: Get Comment Body
         id: get-comment-body

--- a/.github/workflows/nextjs_bundle_analysis.yml
+++ b/.github/workflows/nextjs_bundle_analysis.yml
@@ -29,17 +29,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 21.x
+          node-version: 22.x
           cache: 'pnpm'
-
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules/.cache/turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-19.x-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-
 
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
-      - name: Turbo Cache
-        id: turbo-cache
-        uses: actions/cache@v4
-        with:
-          path: node_modules/.cache/turbo
-          key: turbo-${{ github.job }}-${{ github.ref_name }}-${{ matrix.node-version }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ github.job }}-${{ github.ref_name }}-${{ matrix.node-version }}
-
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 21.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@v4
@@ -74,26 +74,26 @@ jobs:
         run: pnpm lint
 
       - name: Check types
-        if: matrix.node-version == '21.x'
+        if: matrix.node-version == '22.x'
         run: pnpm check-types
 
       - name: Install Playwright
-        if: matrix.node-version == '21.x'
+        if: matrix.node-version == '22.x'
         # Requires root permissions
         run: pnpm -C site exec playwright install chromium --with-deps
 
       - name: Build Storybook
-        if: matrix.node-version == '21.x'
+        if: matrix.node-version == '22.x'
         run: pnpm build-storybook -- --quiet
 
       - name: Serve Storybook and test with coverage
-        if: matrix.node-version == '21.x'
+        if: matrix.node-version == '22.x'
         run: pnpx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
           "pnpx serve site/storybook-static -L -p 6006" \
           "pnpx wait-on tcp:6006 && pnpm coverage"
 
       - name: Upload coverage reports to Codecov
-        if: matrix.node-version == '21.x'
+        if: matrix.node-version == '22.x'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         node-version: [18.x, 21.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The repo consists of three main packages:
 
 - ### site
 
-  The site, built on Next.js and deployed to Vercel. Tested with unit tests and a [public Storybook](https://junat-live-storybook.vercel.app/) with automatic e2e and integration tests. 
+  The site, built on Next.js and deployed to Vercel. Tested with unit tests and a [public Storybook](https://junat-live-storybook.vercel.app/) with automatic e2e and integration tests.
 
 - ### packages/digitraffic
 
@@ -42,12 +42,9 @@ The repo consists of three main packages:
   ```
 
 ## Developing locally
-Node.js version 18 is required; 18 and 21 are tested. 
 
-First, clone the repository with your preferred method. Whether that be the Github CLI, degit or just git commands.
+Node.js version 20 is required; 20 and 22 are tested.
 
-This repository uses [pnpm](https://pnpm.io/) for package management so you should have it installed. If you don't, you can simply run `npm i -g pnpm` to install it.
-
-```sh
-pnpm install && pnpm dev
-```
+1. Clone the repository with your preferred method. Whether that be the Github CLI, degit or just git commands.
+2. This repository uses [pnpm](https://pnpm.io/) for package management so you should have it installed. If you don't, you can simply run `corepack enable && corepack install` to install it. Note that, as of [version v9 of pnpm](https://github.com/pnpm/pnpm/releases/tag/v9.0.0), pnpm requires you to use the version specified in package.json packageManager field.
+3. Run `pnpm install`. For the first run running `pnpm dev` from the workspace root builds the packages.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "prettier": "@junat/prettier",
   "engines": {
-    "node": ">=18.17"
+    "node": ">=20"
   },
   "packageManager": "pnpm@9.2.0+sha512.98a80fd11c2e7096747762304106432b3ddc67dcf54b5a8c01c93f68a2cd5e05e6821849522a06fb76284d41a2660d5e334f2ee3bbf29183bf2e739b1dafa771",
   "pnpm": {

--- a/packages/digitraffic-mqtt/package.json
+++ b/packages/digitraffic-mqtt/package.json
@@ -11,7 +11,7 @@
   ],
   "engineStrict": true,
   "engines": {
-    "node": ">=14.8"
+    "node": ">=20"
   },
   "scripts": {
     "build": "rimraf dist/* && tsc --build && rollup -c",

--- a/packages/digitraffic/package.json
+++ b/packages/digitraffic/package.json
@@ -47,7 +47,6 @@
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/node": "20.12.11",
     "@vitest/ui": "1.6.0",
-    "abort-controller": "^3.0.0",
     "c8": "^9.0.0",
     "eslint": "^8.57.0",
     "eslint-config-junat.live": "workspace:*",

--- a/packages/digitraffic/package.json
+++ b/packages/digitraffic/package.json
@@ -38,7 +38,7 @@
     "lint": "eslint ."
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20"
   },
   "devDependencies": {
     "@junat/prettier": "workspace:*",

--- a/packages/digitraffic/package.json
+++ b/packages/digitraffic/package.json
@@ -60,8 +60,5 @@
     "vite": "^4.4.9",
     "vitest": "1.6.0"
   },
-  "dependencies": {
-    "core-js": "3.34.0"
-  },
   "prettier": "@junat/prettier"
 }

--- a/packages/digitraffic/tests/base/create_fetch.test.ts
+++ b/packages/digitraffic/tests/base/create_fetch.test.ts
@@ -4,10 +4,6 @@ import { createFetch } from '../../src/base/create_fetch'
 import { http, HttpResponse } from 'msw'
 import { server } from '../../mocks/server'
 
-const AbortController =
-  globalThis.AbortController ||
-  (await import('abort-controller').then(m => m.AbortController))
-
 it("throws if path doesn't start with a slash /", () => {
   expect(async () => await createFetch('')).rejects.and.toThrow(TypeError)
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
       eslint-plugin-storybook:
         specifier: ^0.8.0
         version: 0.8.0(eslint@8.57.0)(typescript@5.4.5)
+      fsevents:
+        specifier: ^2.3.3
+        version: 2.3.3
       jsdom:
         specifier: 21.1.2
         version: 21.1.2
@@ -19704,7 +19707,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(jsdom@24.1.0)(terser@5.31.1)
+      vitest: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(jsdom@21.1.2)(terser@5.31.1)
 
   '@vitest/utils@1.3.1':
     dependencies:
@@ -22456,8 +22459,7 @@ snapshots:
   fsevents@2.3.2:
     optional: true
 
-  fsevents@2.3.3:
-    optional: true
+  fsevents@2.3.3: {}
 
   function-bind@1.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,10 +33,6 @@ importers:
         version: 1.5.0(@types/node@20.14.2)(jsdom@24.1.0)(terser@5.31.1)
 
   packages/digitraffic:
-    dependencies:
-      core-js:
-        specifier: 3.34.0
-        version: 3.34.0
     devDependencies:
       '@junat/prettier':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@vitest/ui':
         specifier: 1.6.0
         version: 1.6.0(vitest@1.6.0)
-      abort-controller:
-        specifier: ^3.0.0
-        version: 3.0.0
       c8:
         specifier: ^9.0.0
         version: 9.1.0
@@ -19711,7 +19708,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(jsdom@21.1.2)(terser@5.31.1)
+      vitest: 1.6.0(@types/node@20.12.11)(@vitest/ui@1.6.0)(jsdom@24.1.0)(terser@5.31.1)
 
   '@vitest/utils@1.3.1':
     dependencies:

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,19 +1,21 @@
 # Base is used for all steps and contains necessary dependencies
-FROM node:20.13.1-alpine AS base
+FROM node:22.3.0-alpine3.19 AS base
 WORKDIR /app
 
 # Disable telemetry
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV DOCKER=true
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
 
-RUN npm --global install pnpm@8.6.6
+RUN corepack enable
 RUN apk add --no-cache libc6-compat bash
 RUN apk update
 
 FROM base AS builder
 
 COPY . .
-RUN pnpm dlx turbo prune --scope=site --docker
+RUN pnpx turbo prune --scope=site --docker
 
 FROM base AS installer
 
@@ -24,13 +26,13 @@ COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 COPY --from=builder /app/out/pnpm-workspace.yaml ./pnpm-workspace.yaml
 
 COPY --from=builder /app/out/full/ .
-RUN pnpm install -r
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install
 
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN  \
     --mount=type=secret,id=SENTRY_DSN \  
     export SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) && \
     export NEXT_PUBLIC_SENTRY_DSN=$(cat /run/secrets/SENTRY_DSN) && \
-    pnpm dlx turbo run build --filter=site...
+    pnpx turbo run build --filter=site...
 
 FROM base AS runner
 

--- a/site/package.json
+++ b/site/package.json
@@ -89,6 +89,7 @@
     "eslint-config-junat.live": "workspace:*",
     "eslint-config-next": "^14.2.2",
     "eslint-plugin-storybook": "^0.8.0",
+    "fsevents": "^2.3.3",
     "jsdom": "21.1.2",
     "json-loader": "^0.5.7",
     "msw": "2.2.14",

--- a/site/turbo.json
+++ b/site/turbo.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build", "gql-codegen"],
+      "inputs": ["!src/generated/*"],
+      "outputs": [
+        ".next/**",
+        "!.next/cache/**",
+        "public/sw.js*",
+        "public/workbox*"
+      ],
+      "env": ["NEXT_PUBLIC_SENTRY_DSN"],
+      "outputLogs": "new-only"
+    },
+    "gql-codegen": {
+      "inputs": ["src/lib/digitraffic/{queries,fragments}/*", "codegen.ts"],
+      "outputs": ["src/generated/*"],
+      "outputLogs": "hash-only"
+    }
+  }
+}

--- a/site/turbo.json
+++ b/site/turbo.json
@@ -11,7 +11,7 @@
         "public/sw.js*",
         "public/workbox*"
       ],
-      "env": ["NEXT_PUBLIC_SENTRY_DSN"],
+      "env": ["NEXT_PUBLIC_SENTRY_DSN", "DOCKER"],
       "outputLogs": "new-only"
     },
     "gql-codegen": {

--- a/turbo.json
+++ b/turbo.json
@@ -6,17 +6,6 @@
       "outputs": ["dist/**"],
       "outputLogs": "new-only"
     },
-    "site#build": {
-      "dependsOn": ["^build", "site#gql-codegen"],
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**",
-        "public/sw.js*",
-        "public/workbox*"
-      ],
-      "env": ["NEXT_PUBLIC_SENTRY_DSN"],
-      "outputLogs": "new-only"
-    },
     "test": {
       "dependsOn": ["^build", "site#gql-codegen"],
       "outputs": [],
@@ -40,24 +29,13 @@
         "src/**/*.tsx",
         "src/**/*.ts",
         "tailwind.config.ts",
-        "src/styles/*",
-        "!src/generated/*"
+        "src/styles/*"
       ],
       "outputs": ["storybook-static/**"],
       "outputLogs": "new-only"
     },
     "start": {
       "dependsOn": ["build", "site#gql-codegen"]
-    },
-    "site#gql-codegen": {
-      "inputs": [
-        "src/generated/*",
-        "src/lib/digitraffic/{queries,fragments}/*",
-        "codegen.ts",
-        "package.json"
-      ],
-      "outputs": ["src/generated/*"],
-      "outputLogs": "hash-only"
     }
   }
 }


### PR DESCRIPTION
- Minimum supported Node.js version to 20 
- Node.js 21.x -> 22.x
- Update actions checkout to use Node.js 20
- Remove redundant code (old Node.js compatibility)