### PR TITLE
fix: trains in the past that are cancelled were shown

### DIFF
--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -19,9 +19,9 @@ import { type Code, getFutureTimetableRow, getTrainType } from '~/utils/train'
 import translate from '~/utils/translate'
 
 import {
-    hasLiveEstimateTime as getHasLiveEstimateTime,
-    hasLongTrainType as getHasLongTrainType,
-    getTrainHref
+  hasLiveEstimateTime as getHasLiveEstimateTime,
+  hasLongTrainType as getHasLongTrainType,
+  getTrainHref
 } from './helpers'
 import { useRestoreScrollPosition } from './hooks'
 

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -18,9 +18,9 @@ import { Spinner } from '~/components/spinner'
 import { useStationPage } from '~/hooks/use_station_page'
 import { useTimetableRow } from '~/hooks/use_timetable_row'
 import {
-    useLiveTrains,
-    useLiveTrainsSubscription,
-    useStations
+  useLiveTrains,
+  useLiveTrainsSubscription,
+  useStations
 } from '~/lib/digitraffic'
 import { getErrorQuery } from '~/lib/react_query'
 
@@ -37,7 +37,7 @@ import { StationDropdownMenu } from '~/components/station_dropdown_menu'
 import { useStationFilters } from '~/hooks/use_filters'
 import { useTimetableType } from '~/hooks/use_timetable_type'
 
-import { sortTrains } from '~/utils/train'
+import { sortTrains, toCurrentRows } from '~/utils/train'
 
 export type StationProps = {
   station: LocalizedStation

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -37,7 +37,7 @@ import { StationDropdownMenu } from '~/components/station_dropdown_menu'
 import { useStationFilters } from '~/hooks/use_filters'
 import { useTimetableType } from '~/hooks/use_timetable_type'
 
-import { sortTrains, toCurrentRows } from '~/utils/train'
+import { sortTrains } from '~/utils/train'
 
 export type StationProps = {
   station: LocalizedStation

--- a/site/src/utils/train.test.ts
+++ b/site/src/utils/train.test.ts
@@ -168,29 +168,24 @@ describe('sort trains', () => {
     { type: 'DEPARTURE', msg: 'sorts trains by DEPARTURE' },
     { type: 'ARRIVAL', msg: 'sorts trains by ARRIVAL' }
   ] as const)('$msg', ({ type }) => {
+    const now = new Date()
+
+    const secsInFuture = { 30: 30_000, 10: 10_000, 20: 20_000 }
+
+    function future(secs: keyof typeof secsInFuture) {
+      return new Date(now.getTime() + secsInFuture[secs]).toISOString()
+    }
+
     const trains = [
       {
         timeTableRows: [
           {
-            scheduledTime: new Date(Date.now() * 1.1).toISOString(),
+            scheduledTime: future(30),
             stationShortCode: 'HKI',
             type: 'DEPARTURE'
-          }
-        ]
-      },
-      {
-        timeTableRows: [
+          },
           {
-            scheduledTime: new Date().toISOString(),
-            stationShortCode: 'HKI',
-            type: 'DEPARTURE'
-          }
-        ]
-      },
-      {
-        timeTableRows: [
-          {
-            scheduledTime: new Date(Date.now() * 1.1).toISOString(),
+            scheduledTime: future(30),
             stationShortCode: 'HKI',
             type: 'ARRIVAL'
           }
@@ -199,7 +194,26 @@ describe('sort trains', () => {
       {
         timeTableRows: [
           {
-            scheduledTime: new Date().toISOString(),
+            scheduledTime: future(10),
+            stationShortCode: 'HKI',
+            type: 'DEPARTURE'
+          },
+          {
+            scheduledTime: future(10),
+            stationShortCode: 'HKI',
+            type: 'ARRIVAL'
+          }
+        ]
+      },
+      {
+        timeTableRows: [
+          {
+            scheduledTime: future(20),
+            stationShortCode: 'HKI',
+            type: 'DEPARTURE'
+          },
+          {
+            scheduledTime: future(20),
             stationShortCode: 'HKI',
             type: 'ARRIVAL'
           }
@@ -207,25 +221,18 @@ describe('sort trains', () => {
       }
     ] as const
 
-    if (type === 'ARRIVAL') {
-      expect(sortTrains(trains, 'HKI', type)).toStrictEqual([
-        // Only sorts the trains where type === ARRIVAL, thus the first two elements stay unsorted.
-        trains[0],
-        trains[1],
+    const sorted = sortTrains(trains, 'HKI', type)
 
-        trains[3],
-        trains[2]
-      ])
-    } else {
-      expect(sortTrains(trains, 'HKI', type)).toStrictEqual([
-        trains[1],
-        trains[0],
-
-        // Only sorts the trains where type === DEPARTURE, thus the last two elements stay unsorted.
-        trains[2],
-        trains[3]
-      ])
+    function stime(index: number) {
+      return sorted[index]!.timeTableRows[0].scheduledTime
     }
+    function otime(index: number) {
+      return trains[index]!.timeTableRows[0].scheduledTime
+    }
+
+    expect(stime(0)).toBe(otime(1))
+    expect(stime(1)).toBe(otime(2))
+    expect(stime(2)).toBe(otime(0))
   })
 
   it('does not modify the original array', () => {

--- a/site/src/utils/train.ts
+++ b/site/src/utils/train.ts
@@ -133,7 +133,11 @@ export const sortTrains = <
  * Some trains might depart multiple times from a station. This function gets the timetable row that is closest to departing.
  */
 export const getFutureTimetableRow = <
-  T extends { stationShortCode: string; scheduledTime: string; type: string }
+  T extends {
+    stationShortCode: string
+    scheduledTime: string
+    type: string
+  }
 >(
   stationShortCode: string,
   timetableRows: T[],
@@ -147,11 +151,18 @@ export const getFutureTimetableRow = <
     return
   }
 
-  return (
-    stationTimetableRows.find(({ scheduledTime }) => {
-      return +new Date(scheduledTime) - Date.now() > 0
-    }) || stationTimetableRows.at(-1)
-  )
+  const row =
+    stationTimetableRows.find(
+      ({ scheduledTime }) => Date.parse(scheduledTime) > Date.now()
+    ) || stationTimetableRows.at(-1)
+
+  const cancelledAndInPast =
+    row &&
+    Date.parse(row.scheduledTime) < Date.now() &&
+    'commercialTrack' in row &&
+    row.commercialTrack === ''
+
+  return cancelledAndInPast ? undefined : row
 }
 
 /**

--- a/site/src/utils/train.ts
+++ b/site/src/utils/train.ts
@@ -104,17 +104,8 @@ export const sortTrains = <
   type: 'DEPARTURE' | 'ARRIVAL'
 ) => {
   const byRelativeDate = (a: T, b: T) => {
-    const aRow = getFutureTimetableRow(
-      stationShortCode,
-      [...a.timeTableRows],
-      type
-    )
-
-    const bRow = getFutureTimetableRow(
-      stationShortCode,
-      [...b.timeTableRows],
-      type
-    )
+    const aRow = getFutureTimetableRow(stationShortCode, a.timeTableRows, type)
+    const bRow = getFutureTimetableRow(stationShortCode, b.timeTableRows, type)
 
     if (!(aRow && bRow)) {
       return 0
@@ -140,7 +131,7 @@ export const getFutureTimetableRow = <
   }
 >(
   stationShortCode: string,
-  timetableRows: T[],
+  timetableRows: readonly T[],
   type: 'DEPARTURE' | 'ARRIVAL'
 ): T | undefined => {
   const stationTimetableRows = timetableRows.filter(

--- a/site/src/utils/train.ts
+++ b/site/src/utils/train.ts
@@ -5,7 +5,6 @@ import 'core-js/actual/array/at'
 import 'core-js/actual/array/to-sorted'
 
 import translate from './translate'
-import { station } from '@junat/digitraffic-mqtt'
 
 export type Codes = [
   'AE',


### PR DESCRIPTION
## Example where screenshots were taken at 22:00

| 🔴  Showing old trains | ✅ Not showing old trains, sorted |
|:--------:|:--------:|
| ![localhost_3000_aviapolis](https://github.com/jqpe/junat.live/assets/65775308/97daa169-7900-401b-acf8-86eb913dff3b) | ![localhost_3000_en_aviapolis](https://github.com/jqpe/junat.live/assets/65775308/518ae6f2-6df1-4d84-8f42-0ef42c2608c0) |
