### PR TITLE
fix: site cache

### DIFF
--- a/site/turbo.json
+++ b/site/turbo.json
@@ -4,14 +4,22 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "gql-codegen"],
-      "inputs": ["!src/generated/*"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!vite.config.ts",
+        "!**/*.test.*",
+        "!**/*.stories.tsx",
+        "!src/generated/",
+        "!.storybook/",
+        "!tests/"
+      ],
       "outputs": [
         ".next/**",
         "!.next/cache/**",
         "public/sw.js*",
         "public/workbox*"
       ],
-      "env": ["NEXT_PUBLIC_SENTRY_DSN", "DOCKER"],
+      "env": ["NEXT_PUBLIC_SENTRY_DSN", "SENTRY_AUTH_TOKEN", "DOCKER"],
       "outputLogs": "new-only"
     },
     "gql-codegen": {


### PR DESCRIPTION
- Use the special `$TURBO_DEFAULT$` key to include all git tracked files as inputs
- Exclude files that are related to testing or generated
- Turbo runs in strict mode, meaning it will remove environment variables not marked as dependencies. SENTRY_AUTH_TOKEN was never passed to the build process causing sourcemaps not to be uploaded.
