### PR TITLE
ci: don't run codeql as part of the regular ci/cd

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,6 @@
 name: 'CodeQL'
 
 on:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
   schedule:
     - cron: '35 1 * * 4'
 


### PR DESCRIPTION
This is not contributing much and is just additional noise. Might re-enable if there's backend logic or something else security-sensitive.