### PR TITLE
feat: minor accessibility improvements 

### DIFF
--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -149,6 +149,10 @@
   "emptyFavoritesHeading": "You haven't added favorites yet 🤔",
   "emptyFavoritesBody": "You can add stations to your favorites in station screen menu.",
 
+  "{ train } from { track } to { station }": "{ train } from track { track } to { station }",
+  "scheduled departure { time } estimated { estimate }": "Scheduled departure { time } o'clock {estimate, select, undefined {} other {(estimate {estimate})}}",
+  "scheduled arrival { time } estimated { estimate }": "Scheduled arrival { time } o'clock {estimate, select, undefined {} other {(estimate {estimate})}}",
+
   "stations": {
     "PAU": "Pasila car-carrier station",
     "PNÄ": "Jakobstad-Pedersöre",

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -153,6 +153,8 @@
   "scheduled departure { time } estimated { estimate }": "Scheduled departure { time } o'clock {estimate, select, undefined {} other {(estimate {estimate})}}",
   "scheduled arrival { time } estimated { estimate }": "Scheduled arrival { time } o'clock {estimate, select, undefined {} other {(estimate {estimate})}}",
 
+  "close dialog": "Close dialog",
+
   "stations": {
     "PAU": "Pasila car-carrier station",
     "PNÄ": "Jakobstad-Pedersöre",

--- a/packages/i18n/src/fi.json
+++ b/packages/i18n/src/fi.json
@@ -153,6 +153,8 @@
   "scheduled departure { time } estimated { estimate }": "Suunniteltu lähtö kello { time } {estimate, select, undefined {} other {(arvioitu {estimate})}}",
   "scheduled arrival { time } estimated { estimate }": "Suunniteltu saapuminen kello { time } {estimate, select, undefined {} other {(arvioitu {estimate})}}",
 
+  "close dialog": "Sulje ponnahdusikkuna",
+
   "stations": {},
 
   "routes": {

--- a/packages/i18n/src/fi.json
+++ b/packages/i18n/src/fi.json
@@ -149,6 +149,10 @@
   "emptyFavoritesHeading": "Et ole lisännyt suosikkeja vielä 🤔",
   "emptyFavoritesBody": "Voit lisätä aseman suosiksi asemanäytön valikossa.",
 
+  "{ train } from { track } to { station }": "{ train } raiteelta { track } { station }",
+  "scheduled departure { time } estimated { estimate }": "Suunniteltu lähtö kello { time } {estimate, select, undefined {} other {(arvioitu {estimate})}}",
+  "scheduled arrival { time } estimated { estimate }": "Suunniteltu saapuminen kello { time } {estimate, select, undefined {} other {(arvioitu {estimate})}}",
+
   "stations": {},
 
   "routes": {

--- a/packages/i18n/src/sv.json
+++ b/packages/i18n/src/sv.json
@@ -153,6 +153,8 @@
   "scheduled departure { time } estimated { estimate }": "Planerad avgång kl. { time } {estimate, select, undefined {} other {(beräknad {estimate})}}",
   "scheduled arrival { time } estimated { estimate }": "Planerad ankomst kl. { time } {estimate, select, undefined {} other {(beräknad {estimate})}}",
 
+  "close dialog": "Stäng dialogrutan",
+
   "stations": {
     "TPE": "Tammerfors",
     "PAU": "Böle biltågsstation",

--- a/packages/i18n/src/sv.json
+++ b/packages/i18n/src/sv.json
@@ -149,6 +149,10 @@
   "emptyFavoritesHeading": "Inga favoritstationer än 🤔",
   "emptyFavoritesBody": "Du kan lägga till stationen till dina favoriter i stationsskärmmenyn.",
 
+  "{ train } from { track } to { station }": "{ train } från spår { track } till { station }",
+  "scheduled departure { time } estimated { estimate }": "Planerad avgång kl. { time } {estimate, select, undefined {} other {(beräknad {estimate})}}",
+  "scheduled arrival { time } estimated { estimate }": "Planerad ankomst kl. { time } {estimate, select, undefined {} other {(beräknad {estimate})}}",
+
   "stations": {
     "TPE": "Tammerfors",
     "PAU": "Böle biltågsstation",

--- a/site/src/components/dialog/index.tsx
+++ b/site/src/components/dialog/index.tsx
@@ -13,8 +13,10 @@ import {
 } from '@radix-ui/react-dialog'
 import { cx } from 'cva'
 
+import { useModalFix } from '~/components/dialog/modal_fix_hook'
 import Close from '~/components/icons/close.svg'
 import { PrimaryButton } from '~/components/primary_button'
+import { useTranslations } from '~/i18n'
 
 export type DialogProps = ComponentProps<typeof DialogPortal> & {
   description: ReactNode | ReactNode[]
@@ -54,20 +56,9 @@ export function Dialog({
 
   ...props
 }: DialogProps) {
-  // JUN-227 — using two components which both use https://www.npmjs.com/package/react-remove-scroll causes
-  // both to calculate removed scrollbar. Since the first one sets margin-right the other will instead apply to padding,
-  // effectively offsetting body by --removed-body-scroll-bar-size
-  React.useEffect(() => {
-    if (!fixModal) return
+  const t = useTranslations()
 
-    const body = document.querySelector('body')
-    const margin = body?.style.getPropertyValue('margin-right')
-    const padding = body?.style.getPropertyValue('padding-right')
-
-    if (![margin, padding].includes(undefined) && padding === margin) {
-      body?.style.setProperty('padding-right', '0px')
-    }
-  }, [fixModal])
+  void useModalFix(fixModal)
 
   return (
     <DialogPortal {...props}>
@@ -97,7 +88,10 @@ export function Dialog({
 
         <div data-children>{children}</div>
 
-        <DialogClose className="absolute right-[10px] top-[10px] flex rounded-full">
+        <DialogClose
+          aria-label={t('close dialog')}
+          className="absolute right-[10px] top-[10px] flex rounded-full"
+        >
           <Close className="fill-gray-600" />
         </DialogClose>
       </DialogContent>

--- a/site/src/components/dialog/modal_fix_hook.ts
+++ b/site/src/components/dialog/modal_fix_hook.ts
@@ -1,0 +1,20 @@
+import React from 'react'
+
+/**
+ * JUN-227 — using two components which both use https://www.npmjs.com/package/react-remove-scroll causes
+ * both to calculate removed scrollbar. Since the first one sets margin-right the
+ * other will instead apply to padding, effectively offsetting body by --removed-body-scroll-bar-size
+ */
+export const useModalFix = (fixModal?: boolean) => {
+  React.useEffect(() => {
+    if (!fixModal) return
+
+    const body = document.querySelector('body')
+    const margin = body?.style.getPropertyValue('margin-right')
+    const padding = body?.style.getPropertyValue('padding-right')
+
+    if (![margin, padding].includes(undefined) && padding === margin) {
+      body?.style.setProperty('padding-right', '0px')
+    }
+  }, [fixModal])
+}

--- a/site/src/components/menu/drawer.tsx
+++ b/site/src/components/menu/drawer.tsx
@@ -85,26 +85,24 @@ export const MenuDrawer = ({
         <ul
           className={cx(
             'm-auto flex h-[calc(100%-var(--header-height))] max-w-[500px]',
-            'flex-col justify-between px-[1.875rem] py-9',
+            'flex-col gap-10 px-[1.875rem] py-9',
           )}
         >
-          <div className="flex flex-col gap-10">
-            <MenuItem
-              aria-label={t('contactLabel')}
-              href="mailto:support@junat.live"
-            >
-              {t('contact')}
-            </MenuItem>
-            <MenuItem
-              aria-current={router.pathname === '/settings' ? 'page' : 'false'}
-              href={`/${t('routes.settings')}`}
-              onClick={() => setIsOpen(false)}
-            >
-              {t('settings')}
-            </MenuItem>
-          </div>
+          <MenuItem
+            aria-label={t('contactLabel')}
+            href="mailto:support@junat.live"
+          >
+            {t('contact')}
+          </MenuItem>
+          <MenuItem
+            aria-current={router.pathname === '/settings' ? 'page' : 'false'}
+            href={`/${t('routes.settings')}`}
+            onClick={() => setIsOpen(false)}
+          >
+            {t('settings')}
+          </MenuItem>
 
-          <div>
+          <li className="mt-auto">
             <ToggleButton
               aria-label={t(checked ? 'darkMode' : 'lightMode')}
               data-menu-item={true}
@@ -121,7 +119,7 @@ export const MenuDrawer = ({
               <Sun className="fill-[#000] dark:fill-white" />
               <Moon className="fill-[#000] dark:fill-white" />
             </ToggleButton>
-          </div>
+          </li>
         </ul>
       </motion.nav>
     </RemoveScroll>

--- a/site/src/components/timetable_row/helpers.ts
+++ b/site/src/components/timetable_row/helpers.ts
@@ -1,0 +1,51 @@
+import type { GetTranslatedValue } from '@junat/core/i18n'
+import type { Code } from '@junat/core/utils/train'
+import type { TimetableRowTrain } from '~/components/timetable_row'
+import type { LocalizedStation } from '~/lib/digitraffic'
+import type { Locale } from '~/types/common'
+
+import { To } from 'frominto'
+
+import { getTrainType } from '@junat/core/utils/train'
+
+type GetTrainLabelTrain = {
+  commuterLineID?: string
+  trainType: string
+  trainNumber: number
+}
+
+/** If the train has a commuter line id, e.g. R-train, otherwise train number e.g. Train 3020 */
+export const getTrainDescription = (
+  train: TimetableRowTrain,
+  t: GetTranslatedValue,
+): string => {
+  return 'commuterLineID' in train
+    ? `${train.commuterLineID}-${t('train')}`
+    : `${t('train')} ${train.trainNumber}`
+}
+
+/** If locale is Finnish return illative, e.g. Helsinki -> Helsinkiin */
+export const getStationNameIllative = (
+  locale: Locale,
+  targetName: LocalizedStation | undefined,
+): string | undefined => {
+  return locale === 'fi' && targetName
+    ? To(targetName.stationName.fi)
+    : targetName?.stationName[locale]
+}
+
+export const getTrainLabel = (
+  train: GetTrainLabelTrain,
+  t: GetTranslatedValue,
+): string => {
+  if (train.commuterLineID) {
+    return `${train.commuterLineID}-${t('train')}`
+  }
+
+  const type = getTrainType(train.trainType as Code, {
+    train: t('train'),
+    trainTypes: t('trainTypes'),
+  })
+
+  return `${type} ${train.trainNumber}`
+}

--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -165,7 +165,11 @@ function TimetableRowComponent({
       station: getStationNameIllative(locale, targetStation),
     }
 
-    const timeArgs = { time: scheduledTime, estimate: liveEstimateTime }
+    const timeArgs = {
+      time: scheduledTime,
+      estimate:
+        liveEstimateTime === scheduledTime ? undefined : liveEstimateTime,
+    }
 
     const trainDescription = i(
       t('{ train } from { track } to { station }'),

--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -1,6 +1,4 @@
 import type { AnimationControls } from 'framer-motion'
-import type { GetTranslatedValue } from '@junat/core/i18n'
-import type { Code } from '@junat/core/utils/train'
 import type { Train } from '@junat/digitraffic/types'
 import type { LocalizedStation } from '~/lib/digitraffic'
 import type { Locale } from '~/types/common'
@@ -11,6 +9,7 @@ import { useRouter } from 'next/router'
 import { cx } from 'cva'
 import { motion, useAnimation } from 'framer-motion'
 
+import { interpolateString as i } from '@junat/core/i18n'
 import { getFormattedTime } from '@junat/core/utils/date'
 import {
   getDestinationTimetableRow,
@@ -18,9 +17,13 @@ import {
   hasLiveEstimateTime as getHasLiveEstimateTime,
   hasLongTrainType as getHasLongTrainType,
   getTrainHref,
-  getTrainType,
 } from '@junat/core/utils/train'
 
+import {
+  getStationNameIllative,
+  getTrainDescription,
+  getTrainLabel,
+} from '~/components/timetable_row/helpers'
 import { useTimetableRow } from '~/hooks/use_timetable_row'
 import { useTranslations } from '~/i18n'
 import { useRestoreScrollPosition } from './hooks'
@@ -144,7 +147,7 @@ function TimetableRowComponent({
     })
   }, [controls, isLastStation, timetableRef])
 
-  const targetName = stations.find(
+  const targetStation = stations.find(
     station => station.stationShortCode === targetRow?.stationShortCode,
   )
 
@@ -153,8 +156,33 @@ function TimetableRowComponent({
     setTimetableRowId(timetableRowId)
   }
 
+  const getRowAriaLabel = (): string => {
+    const { commercialTrack: track } = currentRow
+
+    const trainArgs = {
+      train: getTrainDescription(train, t),
+      track,
+      station: getStationNameIllative(locale, targetStation),
+    }
+
+    const timeArgs = { time: scheduledTime, estimate: liveEstimateTime }
+
+    const trainDescription = i(
+      t('{ train } from { track } to { station }'),
+      trainArgs,
+    )
+    const rowType = type === 'ARRIVAL' ? 'arrival' : 'departure'
+    const timeDescription = i(
+      t(`scheduled ${rowType} { time } estimated { estimate }`),
+      timeArgs,
+    )
+
+    return `${trainDescription}. ${timeDescription}`
+  }
+
   return (
     <motion.tr
+      aria-label={getRowAriaLabel()}
       role="button"
       tabIndex={0}
       onKeyDown={event => {
@@ -190,7 +218,7 @@ function TimetableRowComponent({
         delay: animation?.delay,
       }}
     >
-      <Td>{targetName?.stationName[locale]}</Td>
+      <Td>{targetStation?.stationName[locale]}</Td>
 
       <Td>
         {train.cancelled ? (
@@ -243,25 +271,3 @@ export const TimetableRow = (props: TimetableRowProps) => {
 }
 
 export default TimetableRow
-
-type GetTrainLabelTrain = {
-  commuterLineID?: string
-  trainType: string
-  trainNumber: number
-}
-
-const getTrainLabel = (
-  train: GetTrainLabelTrain,
-  t: GetTranslatedValue,
-): string => {
-  if (train.commuterLineID) {
-    return `${train.commuterLineID}-${t('train')}`
-  }
-
-  const type = getTrainType(train.trainType as Code, {
-    train: t('train'),
-    trainTypes: t('trainTypes'),
-  })
-
-  return `${type} ${train.trainNumber}`
-}


### PR DESCRIPTION
- _fix_ Main navigation used divs inside unordered list
- _fix_ Dialog close button did not have an accessible name 
- _feature_ Timetable row now provides a better UX for users using a screenreader (see below)

<table>
<thead>
<tr>
<td>old</td>
<td>new</td>
</tr>
</thead>
<tbody>
<tr>
<td>

<img width="470" alt="Example of bad accessible name in old version of Junat.live" src="https://github.com/user-attachments/assets/705e3e09-81b9-45ae-9e08-8589615b030c">

</td>

<td>

<img width="494" alt="Example of a good accessible name in an upcoming version of Junat.live" src="https://github.com/user-attachments/assets/d01ec037-32e2-40fa-acf2-9f0ace8eef5b">

</td>
</tr>
</tbody>
</table>
