### PR TITLE
fix: use just-in-time for @junat/react-hooks

### DIFF
--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -1,0 +1,5 @@
+<h1>react-hooks <img src="https://junat.live/maskable_icon.png" align="right" width="38px" alt="Junat.live logo"></h1>
+
+Requires Just-in-Time (JIT) compilation at the callsite. Without JIT compilation, a separate Zustand instance will be created, resulting in empty stores at the callsite.
+
+For Vite projects, this functionality works out of the box. For Next.js projects, use the `transpilePackages` option in your configuration and include `@junat/react-hooks`.

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -6,18 +6,16 @@
   "sideEffects": false,
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "dev": "tsup --watch",
-    "build": "tsup",
     "test": "vitest run",
     "check-types": "tsc --noEmit --emitDeclarationOnly false",
     "coverage": "vitest run --coverage",
     "lint": "eslint ."
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./*": "./dist/*.js",
-    "./digitraffic/*": "./dist/digitraffic/*.js",
-    "./digitraffic": "./dist/digitraffic/index.js"
+    ".": "./src/index.ts",
+    "./*": "./src/*.ts",
+    "./digitraffic/*": "./src/digitraffic/*.ts",
+    "./digitraffic": "./src/digitraffic/index.ts"
   },
   "devDependencies": {
     "@junat/core": "workspace:^",

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -15,6 +15,7 @@ export const nextConfig = {
     outputFileTracingRoot: path.join(process.cwd(), '..'),
     instrumentationHook: true,
   },
+  transpilePackages: ['@junat/react-hooks'],
   i18n: {
     locales: [...LOCALES],
     defaultLocale: 'fi',


### PR DESCRIPTION
Fixes a bug that caused empty stores in Next.js application. There were two Zustand instances, thus stores remained empty breaking functionality. Using JIT complilation we can still use a separate package and share code between app and site, with the tradeoff of always having to build the code.