### PR TITLE
feat: remove use of beta client for station passenger info

### DIFF
--- a/packages/graphql/src/graphql_request.ts
+++ b/packages/graphql/src/graphql_request.ts
@@ -6,8 +6,3 @@ export const client = new GraphQLClient(
   'https://rata.digitraffic.fi/api/v2/graphql/graphql',
   { fetch: fetchWithError },
 )
-
-export const betaClient = new GraphQLClient(
-  'https://rata-beta.digitraffic.fi/api/v2/graphql/graphql',
-  { fetch: fetchWithError },
-)

--- a/packages/react-hooks/src/digitraffic/use_station_passenger_info.ts
+++ b/packages/react-hooks/src/digitraffic/use_station_passenger_info.ts
@@ -2,9 +2,8 @@ import type { StationPassengerInfoQuery } from '@junat/graphql'
 
 import { useQuery } from '@tanstack/react-query'
 
-// TODO: remove beta client when production api reaches feature parity
-import { betaClient } from '@junat/graphql/graphql-request'
 import { stationPassengerInfo } from '@junat/graphql/queries/passenger_info'
+import { client } from '@junat/graphql/graphql-request'
 
 /**
  * Fetch generic station passenger information, see
@@ -28,7 +27,7 @@ export const fetchStationPassengerInfo = async (
 ): Promise<
   StationPassengerInfoQuery['passengerInformationMessagesByStation']
 > => {
-  const result = await betaClient.request(stationPassengerInfo, {
+  const result = await client.request(stationPassengerInfo, {
     stationShortCode,
   })
 


### PR DESCRIPTION
The beta client is being used for test messages.
