### PR TITLE
fix: adhere to css spec in pointer use

### DIFF
--- a/packages/ui/src/components/animated_button.tsx
+++ b/packages/ui/src/components/animated_button.tsx
@@ -29,11 +29,11 @@ export function AnimatedButton(props: AnimatedButtonProps) {
       {visible && (
         <motion.button
           className={cx(
-            'relative z-[1] mx-auto cursor-pointer select-none overflow-hidden rounded-full',
-            'border-[1px] border-solid border-primary-600 px-[1.25rem] py-[0.3125rem] font-ui',
-            'disabled:bg-gray-100 dark:border-primary-400 dark:disabled:bg-gray-900',
-            'text-primary-800 disabled:cursor-not-allowed disabled:border-primary-300',
-            'dark:bg-gray-900 dark:text-primary-200 dark:disabled:border-primary-800',
+            'relative z-[1] mx-auto overflow-hidden rounded-full select-none',
+            'border-primary-600 font-ui border-[1px] border-solid px-[1.25rem] py-[0.3125rem]',
+            'dark:border-primary-400 disabled:bg-gray-100 dark:disabled:bg-gray-900',
+            'text-primary-800 disabled:border-primary-300 disabled:cursor-not-allowed',
+            'dark:text-primary-200 dark:disabled:border-primary-800 dark:bg-gray-900',
           )}
           whileTap={{ scale: isLoading ? 1 : 1.1 }}
           whileHover={{ scale: isLoading ? 1 : 1.05 }}
@@ -45,7 +45,7 @@ export function AnimatedButton(props: AnimatedButtonProps) {
           {...buttonProps}
         >
           <div
-            className="absolute inset-0 z-0 max-w-[inherit] animate-translate"
+            className="animate-translate absolute inset-0 z-0 max-w-[inherit]"
             style={{ animation: isLoading ? undefined : 'none' }}
           >
             <Background />

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -10,16 +10,16 @@ export interface ButtonProps extends VariantProps<typeof button> {
 
 const button = cva({
   base: cx(
-    'cursor-pointer rounded-full bg-gray-800 p-[2px_15px] font-ui text-[14px]',
+    'font-ui rounded-full bg-gray-800 p-[2px_15px] text-[14px]',
     '[transition:border-color_250ms_ease-out_,_background_150ms_ease-out]',
-    'select-none text-gray-100 hover:bg-gray-700 focus-visible:border-[2px]',
+    'text-gray-100 select-none hover:bg-gray-700 focus-visible:border-[2px]',
     '[border:2px_solid_transparent] focus-visible:outline-none dark:border-gray-700',
     'focus-visible:border-primary-500 dark:border-[1px]',
   ),
   variants: {
     variant: {
       'notification-badge': cx(
-        'mr-auto bg-secondary-200 hover:bg-secondary-300 focus-visible:border-secondary-500',
+        'bg-secondary-200 hover:bg-secondary-300 focus-visible:border-secondary-500 mr-auto',
         'dark:border-secondary-600 dark:bg-secondary-800 dark:text-secondary-100',
         'text-secondary-600 dark:focus-visible:border-secondary-500',
         'dark:hover:bg-secondary-700',

--- a/packages/ui/src/components/dropdown_menu/dropdown_menu.tsx
+++ b/packages/ui/src/components/dropdown_menu/dropdown_menu.tsx
@@ -35,7 +35,7 @@ export const DropdownMenu = (props: Props) => {
         <button
           data-testid={TRIGGER_TEST_ID}
           className={cx(
-            'relative inline-flex h-[35px] w-[35px] cursor-pointer items-center justify-center',
+            'relative inline-flex h-[35px] w-[35px] items-center justify-center',
             'flex-shrink-0 rounded-full border-2 border-transparent bg-gray-300 fill-gray-800',
             'focus-visible:outline-none dark:bg-gray-700 dark:fill-gray-400',
             'text-primary-900 focus-visible:[border:2px_solid_theme(colors.primary.500)]',

--- a/packages/ui/src/components/dropdown_menu/item.tsx
+++ b/packages/ui/src/components/dropdown_menu/item.tsx
@@ -17,7 +17,7 @@ export const Item = React.forwardRef<HTMLDivElement, DropdownMenuItemProps>(
 )
 
 export const className = cx(
-  'grid select-none grid-cols-[1fr,24px] rounded-sm px-3 duration-200',
-  'min-h-[35px] cursor-pointer items-center font-ui text-[13px]',
+  'grid grid-cols-[1fr,24px] rounded-sm px-3 duration-200 select-none',
+  'font-ui min-h-[35px] items-center text-[13px]',
   'transition-[background-color] focus-visible:bg-gray-100 dark:focus-visible:bg-gray-700',
 )

--- a/packages/ui/src/components/floating_action_button.tsx
+++ b/packages/ui/src/components/floating_action_button.tsx
@@ -9,7 +9,7 @@ export function FloatingActionButton<T extends React.ElementType = 'button'>(
   return (
     <As
       className={cx(
-        'fixed bottom-[1rem] right-[1rem] flex cursor-pointer rounded-full p-[0.75rem]',
+        'fixed right-[1rem] bottom-[1rem] flex rounded-full p-[0.75rem]',
         'bg-primary-700 shadow-[2px_2px_30px_rgba(0,0,0,0.15)] lg:right-[calc(50%-300px)]',
       )}
       type="button"

--- a/packages/ui/src/components/hamburger_menu.tsx
+++ b/packages/ui/src/components/hamburger_menu.tsx
@@ -1,8 +1,8 @@
-import type { GetTranslatedValue } from '@junat/core/i18n'
 import type { Spring, Variants } from 'motion/react'
+import type { GetTranslatedValue } from '@junat/core/i18n'
 
-import { motion } from 'motion/react'
 import React from 'react'
+import { motion } from 'motion/react'
 
 type Props = {
   onOpenChange: (open: boolean) => void
@@ -38,7 +38,7 @@ export const HamburgerMenu = (props: Props) => {
       data-menu-item={true}
       id="menu"
       onClick={handleOnClick}
-      className="flex cursor-pointer p-1.5 focus-visible:outline-offset-0"
+      className="flex p-1.5 focus-visible:outline-offset-0"
       aria-label={t(
         `menu.navbar.${props.isOpen ? 'iconLabelCollapse' : 'iconLabelExpand'}`,
       )}

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -29,7 +29,7 @@ export function Select(props: SelectProps) {
       <Primitive.Trigger
         aria-label={props.label}
         className={cx(
-          'flex cursor-pointer select-none gap-[10px]',
+          'flex gap-[10px] select-none',
           'bg-gray-800 p-[5px_15px] text-gray-200',
         )}
       >
@@ -54,7 +54,7 @@ export function Select(props: SelectProps) {
                 value={key}
                 key={key}
                 className={cx(
-                  'flex select-none items-center rounded-full p-[0px_10px] transition-colors',
+                  'flex items-center rounded-full p-[0px_10px] transition-colors select-none',
                   'data-[highlighted]:bg-grayA-400 data-[highlighted]:dark:bg-grayA-300',
                   'duration-200 [animation-timing-function:sine-in]',
                 )}

--- a/site/src/features/pages/station/components/page.tsx
+++ b/site/src/features/pages/station/components/page.tsx
@@ -158,8 +158,8 @@ export function Station({ station, locale }: StationProps) {
             {destination && (
               <button
                 className={cx(
-                  'rounded-sm bg-error-600 p-1 font-ui text-sm leading-4 text-error-200',
-                  'cursor-pointer focus-visible:outline-offset-0 focus-visible:outline-error-700',
+                  'bg-error-600 font-ui text-error-200 rounded-sm p-1 text-sm leading-4',
+                  'focus-visible:outline-error-700 focus-visible:outline-offset-0',
                 )}
                 onClick={() => setDestination('')}
               >

--- a/site/src/features/pages/station/components/weather_badge.tsx
+++ b/site/src/features/pages/station/components/weather_badge.tsx
@@ -48,7 +48,7 @@ export const WeatherBadge = (props: WeatherBadgeProps) => {
           <button
             className={cx(
               'flex flex-row items-center justify-center gap-1',
-              'mr-3 w-fit cursor-pointer select-none',
+              'mr-3 w-fit select-none',
             )}
           >
             <span className="whitespace-nowrap">


### PR DESCRIPTION
While some parts of the UI already did not use pointer cursors (e.g. toggle), it was still used a lot. Adhere to the [spec](https://drafts.csswg.org/css-ui-3/\#valdef-cursor-pointer) and remove `cursor: pointer` from interactive elements that are not links. 

Below, a good example why cursor misuse could result in a confusing UX. The last item is a link while the others are interactive elements (open a dialog, add to favorites...) 

https://github.com/user-attachments/assets/beacdc09-7495-499d-b13f-1d75c61c1cfd

