### PR TITLE
fix: improve accessibility

### DIFF
--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -160,8 +160,8 @@
   "emptyFavoritesBody": "You can add stations to your favorites in station screen menu.",
 
   "{ train } from { track } to { station }": "{ train } from track { track } to { station }",
-  "scheduled departure { time } estimated { estimate }": "Scheduled departure { time } o'clock {estimate, select, undefined {} other {(estimate {estimate})}}",
-  "scheduled arrival { time } estimated { estimate }": "Scheduled arrival { time } o'clock {estimate, select, undefined {} other {(estimate {estimate})}}",
+  "scheduled departure { time } estimated { estimate }": "{estimate, select, undefined {Departs at { time }} other {(Estimated departure {estimate})}}",
+  "scheduled arrival { time } estimated { estimate }": "{estimate, select, undefined {Arrives by { time }} other {(Estimated arrival {estimate})}}",
 
   "close dialog": "Close dialog",
 

--- a/packages/i18n/src/en.json
+++ b/packages/i18n/src/en.json
@@ -28,7 +28,9 @@
   "available": "available",
   "metersInSecond": "meters per second",
   "to": "to",
-
+  "departingTrains": "Departing trains",
+  "arrivingTrains": "Arriving trains",
+  
   "schedulesFor { date }": "Schedules for {date}",
   "chooseDate": "Choose a date",
   "changeDepartureDate": "Change the departure date with the input below.",

--- a/packages/i18n/src/fi.json
+++ b/packages/i18n/src/fi.json
@@ -28,6 +28,8 @@
   "available": "saatavilla",
   "metersInSecond": "metriä sekunnissa",
   "to": "",
+  "departingTrains": "Lähtevät junat",
+  "arrivingTrains": "Saapuvat junat",
 
   "schedulesFor { date }": "Aikataulutiedot {date}",
   "chooseDate": "Valitse lähtöpäivä",

--- a/packages/i18n/src/fi.json
+++ b/packages/i18n/src/fi.json
@@ -160,8 +160,8 @@
   "emptyFavoritesBody": "Voit lisätä aseman suosiksi asemanäytön valikossa.",
 
   "{ train } from { track } to { station }": "{ train } raiteelta { track } { station }",
-  "scheduled departure { time } estimated { estimate }": "Suunniteltu lähtö kello { time } {estimate, select, undefined {} other {(arvioitu {estimate})}}",
-  "scheduled arrival { time } estimated { estimate }": "Suunniteltu saapuminen kello { time } {estimate, select, undefined {} other {(arvioitu {estimate})}}",
+  "scheduled departure { time } estimated { estimate }": "{estimate, select, undefined {Lähtö kello { time }} other {(arvioitu {estimate})}}",
+  "scheduled arrival { time } estimated { estimate }": "{estimate, select, undefined {Saapuu kello { time }} other {(arvioitu {estimate})}}",
 
   "close dialog": "Sulje ponnahdusikkuna",
 

--- a/packages/i18n/src/sv.json
+++ b/packages/i18n/src/sv.json
@@ -160,8 +160,8 @@
   "emptyFavoritesBody": "Du kan lägga till stationen till dina favoriter i stationsskärmmenyn.",
 
   "{ train } from { track } to { station }": "{ train } från spår { track } till { station }",
-  "scheduled departure { time } estimated { estimate }": "Planerad avgång kl. { time } {estimate, select, undefined {} other {(beräknad {estimate})}}",
-  "scheduled arrival { time } estimated { estimate }": "Planerad ankomst kl. { time } {estimate, select, undefined {} other {(beräknad {estimate})}}",
+  "scheduled departure { time } estimated { estimate }": "{estimate, select, undefined {Avgår kl. { time }} other {(Beräknad avgång {estimate})}}",
+  "scheduled arrival { time } estimated { estimate }": "{estimate, select, undefined {Ankommer kl. { time }} other {(Beräknad ankomst {estimate})}}",
 
   "close dialog": "Stäng dialogrutan",
 

--- a/packages/i18n/src/sv.json
+++ b/packages/i18n/src/sv.json
@@ -31,7 +31,9 @@
   "available": "tillgängliga",
   "metersInSecond": "meter per sekund",
   "to": "till",
-
+  "departingTrains": "Avgående tåg",
+  "arrivingTrains": "Ankommande tåg",
+  
   "schedulesFor { date }": "Tidtabeller för {date}",
   "chooseDate": "Välj ett datum",
   "changeDepartureDate": "Ändra avresedatum med inmatningen nedan.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: link:tooling/prettier
       '@turbo/gen':
         specifier: ^2.4.4
-        version: 2.4.4(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.14)(typescript@5.8.2)
+        version: 2.4.4(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.16)(typescript@5.8.2)
       c8:
         specifier: ^10.1.3
         version: 10.1.3
@@ -33,7 +33,7 @@ importers:
         version: 2.4.4
       vitest:
         specifier: ^3.0.9
-        version: 3.1.1(@types/node@22.13.14)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.3(@types/node@22.13.14)(typescript@5.8.2))(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
+        version: 3.1.1(@types/node@22.13.16)(jiti@2.4.2)(jsdom@26.0.0)(msw@2.7.3(@types/node@22.13.16)(typescript@5.8.2))(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
 
   packages/core:
     dependencies:
@@ -824,6 +824,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.1
         version: 10.1.1(eslint@9.23.0(jiti@2.4.2))
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.10.2
+        version: 6.10.2(eslint@9.23.0(jiti@2.4.2))
       eslint-plugin-react-compiler:
         specifier: 19.0.0-beta-e993439-20250328
         version: 19.0.0-beta-e993439-20250328(eslint@9.23.0(jiti@2.4.2))
@@ -5272,6 +5275,10 @@ packages:
     resolution: {integrity: sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==}
     engines: {node: '>= 0.4'}
 
+  array.prototype.flatmap@1.3.3:
+    resolution: {integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==}
+    engines: {node: '>= 0.4'}
+
   arraybuffer.prototype.slice@1.0.4:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
@@ -5288,6 +5295,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-types-flow@0.0.8:
+    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
@@ -5343,6 +5353,10 @@ packages:
 
   axios@1.8.4:
     resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -6038,6 +6052,9 @@ packages:
     resolution: {integrity: sha512-YGZxdTTL9lmLkCUTpg4j0zQ7IhRB5ZmqNBbGCl3Tg6MP/d5/6sY7L5mmTjzbc6JKgVZYiqTQTNhPFsbXNGlRaA==}
     engines: {node: '>=0.8'}
 
+  damerau-levenshtein@1.0.8:
+    resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -6467,6 +6484,12 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-jsx-a11y@6.10.2:
+    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
 
   eslint-plugin-react-compiler@19.0.0-beta-e993439-20250328:
     resolution: {integrity: sha512-7hTFaGMz0YYLtkStJFBHjr2zOZwULxg2qCJ8pNYlaOqq2zL1/+Wg7BiDwrPZQIpAn3YQbBu1SHF509M3qpTyIg==}
@@ -7942,6 +7965,13 @@ packages:
   konva@9.3.16:
     resolution: {integrity: sha512-qa47cefGDDHzkToGRGDsy24f/Njrz7EHP56jQ8mlDcjAPO7vkfTDeoBDIfmF7PZtpfzDdooafQmEUJMDU2F7FQ==}
 
+  language-subtag-registry@0.3.23:
+    resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
+
+  language-tags@1.0.9:
+    resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
+    engines: {node: '>=0.10'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -8578,6 +8608,10 @@ packages:
 
   object.assign@4.1.7:
     resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  object.fromentries@2.0.8:
+    resolution: {integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==}
     engines: {node: '>= 0.4'}
 
   object.values@1.2.1:
@@ -10003,6 +10037,10 @@ packages:
 
   string.prototype.codepointat@0.2.1:
     resolution: {integrity: sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==}
+
+  string.prototype.includes@2.0.1:
+    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
+    engines: {node: '>= 0.4'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -15726,7 +15764,7 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/gen@2.4.4(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.14)(typescript@5.8.2)':
+  '@turbo/gen@2.4.4(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.16)(typescript@5.8.2)':
     dependencies:
       '@turbo/workspaces': 2.4.4
       commander: 10.0.1
@@ -15736,7 +15774,7 @@ snapshots:
       node-plop: 0.26.3
       picocolors: 1.0.1
       proxy-agent: 6.5.0
-      ts-node: 10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.14)(typescript@5.8.2)
+      ts-node: 10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.16)(typescript@5.8.2)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -16532,6 +16570,13 @@ snapshots:
       es-abstract: 1.23.9
       es-shim-unscopables: 1.1.0
 
+  array.prototype.flatmap@1.3.3:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+      es-shim-unscopables: 1.1.0
+
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
@@ -16559,6 +16604,8 @@ snapshots:
       util: 0.12.5
 
   assertion-error@2.0.1: {}
+
+  ast-types-flow@0.0.8: {}
 
   ast-types@0.13.4:
     dependencies:
@@ -16609,6 +16656,8 @@ snapshots:
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
+
+  axobject-query@4.1.0: {}
 
   babel-core@7.0.0-bridge.0(@babel/core@7.26.10):
     dependencies:
@@ -17460,6 +17509,8 @@ snapshots:
       find-pkg: 0.1.2
       fs-exists-sync: 0.1.0
 
+  damerau-levenshtein@1.0.8: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   data-uri-to-buffer@6.0.2: {}
@@ -17971,6 +18022,25 @@ snapshots:
   eslint-config-prettier@10.1.1(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       eslint: 9.23.0(jiti@2.4.2)
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.23.0(jiti@2.4.2)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.8
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.23.0(jiti@2.4.2)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-react-compiler@19.0.0-beta-e993439-20250328(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
@@ -19862,6 +19932,12 @@ snapshots:
 
   konva@9.3.16: {}
 
+  language-subtag-registry@0.3.23: {}
+
+  language-tags@1.0.9:
+    dependencies:
+      language-subtag-registry: 0.3.23
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -20718,6 +20794,13 @@ snapshots:
       es-object-atoms: 1.1.1
       has-symbols: 1.1.0
       object-keys: 1.1.1
+
+  object.fromentries@2.0.8:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+      es-object-atoms: 1.1.1
 
   object.values@1.2.1:
     dependencies:
@@ -22315,6 +22398,12 @@ snapshots:
 
   string.prototype.codepointat@0.2.1: {}
 
+  string.prototype.includes@2.0.1:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-abstract: 1.23.9
+
   string.prototype.matchall@4.0.12:
     dependencies:
       call-bind: 1.0.8
@@ -22716,6 +22805,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.11.13(@swc/helpers@0.5.15)
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.11.13(@swc/helpers@0.5.15))(@types/node@22.13.16)(typescript@5.8.2):
     dependencies:
@@ -22736,7 +22826,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.11.13(@swc/helpers@0.5.15)
-    optional: true
 
   ts-pnp@1.2.0(typescript@5.8.2):
     optionalDependencies:

--- a/site/src/components/single_timetable_row/index.tsx
+++ b/site/src/components/single_timetable_row/index.tsx
@@ -73,6 +73,8 @@ export function SingleTimetableRow({
     <tr className="relative mt-[15px] grid grid-cols-[10%_1fr_1fr] items-center first:mt-0">
       <td>
         <svg
+          aria-hidden
+          role="presentation"
           height={24}
           width={24}
           viewBox="0 0 100 100"

--- a/site/src/components/station_dropdown_menu/timetable_type_radio.tsx
+++ b/site/src/components/station_dropdown_menu/timetable_type_radio.tsx
@@ -46,8 +46,12 @@ export const TimetableTypeRadio = (props: {
         htmlFor={htmlFor}
         className="pl-[15px] text-sm leading-none"
       >
-        {current} <span aria-hidden>{'-->'}</span>{' '}  
-        <span className="sr-only">{t('to')}</span> {target}
+        {current}
+        <span className="mx-1" aria-hidden>
+          {'\u2192'}
+        </span>
+        <span className="sr-only">{t('to')}</span>
+        {target}
       </label>
     )
   }

--- a/site/src/components/station_dropdown_menu/trains_filter_dialog.tsx
+++ b/site/src/components/station_dropdown_menu/trains_filter_dialog.tsx
@@ -70,7 +70,17 @@ export const TrainsFilterDialog = (props: Props) => {
       t={t}
       fixModal
       // Allows browsers to adjust dialog to visible viewport when using virtual keyboard.
-      onOpenAutoFocus={event => event.preventDefault()}
+      onOpenAutoFocus={event => {
+        event.preventDefault()
+
+        // Wrapping with reqest animation frame does not break the layout on Safari on iOS
+        window.requestAnimationFrame(() => {
+          if (event.target instanceof HTMLElement) {
+            const input = event.target.querySelector('form input')
+            if (input instanceof HTMLInputElement) input.focus()
+          }
+        })
+      }}
       title={t('filterTrains')}
       description={t('filterTrainsDescription')}
     >

--- a/site/src/components/station_list/index.tsx
+++ b/site/src/components/station_list/index.tsx
@@ -24,7 +24,6 @@ export function StationList({
     <ul id={STATION_LIST_ID} className="flex flex-col gap-[0.725rem]">
       {stations.map((station, i) => (
         <li
-          role="option"
           {...(activeStation === i ? { 'aria-current': true } : {})}
           key={station.stationShortCode}
           className={'aria-[current]:outline'}

--- a/site/src/components/timetable/calculate_delay.test.ts
+++ b/site/src/components/timetable/calculate_delay.test.ts
@@ -1,21 +1,21 @@
 import { expect, it } from 'vitest'
 
-import { calculateDelay } from './index'
+import { animation } from './index'
 
 it('returns 0..19 for the first group', () => {
-  expect(calculateDelay(0)).toBe(0)
-  expect(calculateDelay(19)).toBe(19)
+  expect(animation(0).transition.delay).toBe(0)
+  expect(animation(19).transition.delay).toBe(19)
 })
 
 it('returns 0..79 for the second group', () => {
-  expect(calculateDelay(20)).toBe(0)
-  expect(calculateDelay(99)).toBe(79)
+  expect(animation(20).transition.delay).toBe(0)
+  expect(animation(99).transition.delay).toBe(79)
 })
 
 it('returns 0..100 for the third group and subsequent groups', () => {
-  expect(calculateDelay(100)).toBe(0)
-  expect(calculateDelay(199)).toBe(99)
+  expect(animation(100).transition.delay).toBe(0)
+  expect(animation(199).transition.delay).toBe(99)
 
-  expect(calculateDelay(200)).toBe(0)
-  expect(calculateDelay(299)).toBe(99)
+  expect(animation(200).transition.delay).toBe(0)
+  expect(animation(299).transition.delay).toBe(99)
 })

--- a/site/src/components/timetable/calculate_delay.test.ts
+++ b/site/src/components/timetable/calculate_delay.test.ts
@@ -1,21 +1,21 @@
 import { expect, it } from 'vitest'
 
-import { animation } from './index'
+import { calculateDelay } from './index'
 
 it('returns 0..19 for the first group', () => {
-  expect(animation(0).transition.delay).toBe(0)
-  expect(animation(19).transition.delay).toBe(19)
+  expect(calculateDelay(0)).toBe(0)
+  expect(calculateDelay(19)).toBe(19)
 })
 
 it('returns 0..79 for the second group', () => {
-  expect(animation(20).transition.delay).toBe(0)
-  expect(animation(99).transition.delay).toBe(79)
+  expect(calculateDelay(20)).toBe(0)
+  expect(calculateDelay(99)).toBe(79)
 })
 
 it('returns 0..100 for the third group and subsequent groups', () => {
-  expect(animation(100).transition.delay).toBe(0)
-  expect(animation(199).transition.delay).toBe(99)
+  expect(calculateDelay(100)).toBe(0)
+  expect(calculateDelay(199)).toBe(99)
 
-  expect(animation(200).transition.delay).toBe(0)
-  expect(animation(299).transition.delay).toBe(99)
+  expect(calculateDelay(200)).toBe(0)
+  expect(calculateDelay(299)).toBe(99)
 })

--- a/site/src/components/timetable/index.tsx
+++ b/site/src/components/timetable/index.tsx
@@ -90,27 +90,34 @@ export function Timetable({ trains, ...props }: Readonly<TimetableProps>) {
 
 export default Timetable
 
-export const animation = (index: number) => {
-  const group = Math.floor(index / TRAINS_MULTIPLIER)
-  let delay = index - group * TRAINS_MULTIPLIER
-
+/**
+ * Given a number `index` returns a number 0..99
+ * - If `index` < {@link DEFAULT_TRAINS_COUNT} (e.g. 20) => 0..19
+ * - If `index` < {@link TRAINS_MULTIPLIER} (e.g. 100) => 0..79
+ * - Otherwise 0..99
+ */
+export const calculateDelay = (index: number) => {
   if (index < DEFAULT_TRAINS_COUNT) {
-    delay = index
+    return index
   }
 
   if (index < TRAINS_MULTIPLIER) {
-    delay = index - DEFAULT_TRAINS_COUNT
+    return index - DEFAULT_TRAINS_COUNT
   }
 
-  return {
+  const group = Math.floor(index / TRAINS_MULTIPLIER)
+  return index - group * TRAINS_MULTIPLIER
+}
+
+export const animation = (index: number) =>
+  ({
     opacity: 1,
     transition: {
       stiffness: 170,
       damping: 45,
       mass: 1,
-      delay: sineIn(delay / 100),
+      delay: sineIn(calculateDelay(index) / 100),
     },
-  } satisfies Variant
-}
+  }) satisfies Variant
 
 const sineIn = (t: number) => Math.sin((t * Math.PI) / 2)

--- a/site/src/components/timetable_row/helpers.ts
+++ b/site/src/components/timetable_row/helpers.ts
@@ -17,12 +17,19 @@ type GetTrainLabelTrain = {
 
 /** If the train has a commuter line id, e.g. R-train, otherwise train number e.g. Train 3020 */
 export const getTrainDescription = (
-  train: { commuterLineID?: string; trainNumber: number },
+  train: { commuterLineID?: string; trainNumber: number; trainType?: string },
   t: GetTranslatedValue,
 ): string => {
-  return 'commuterLineID' in train
+  const maybeType = train.trainType
+    ? getTrainType(train.trainType as Code, {
+        train: t('train'),
+        trainTypes: t('trainTypes'),
+      })
+    : undefined
+
+  return train.commuterLineID
     ? `${train.commuterLineID}-${t('train')}`
-    : `${t('train')} ${train.trainNumber}`
+    : `${maybeType || t('train')} ${train.trainNumber}`
 }
 
 /** If locale is Finnish return illative, e.g. Helsinki -> Helsinkiin */

--- a/site/src/components/timetable_row/hooks.tsx
+++ b/site/src/components/timetable_row/hooks.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import type { LocalizedStation } from '@junat/core/types'
 
 import { useRouter } from 'next/router'
+import { formatDate } from 'date-fns'
 
 import { getTrainHref, interpolateString as i } from '@junat/core'
 import { useTimetableRow, useTimetableType } from '@junat/react-hooks'
@@ -46,9 +47,11 @@ export const useTimetableRowA11y = (props: UseTimetableRowA11yProps) => {
     const timeDescription = i(
       t(`scheduled ${rowType} { time } estimated { estimate }`),
       {
-        time: scheduledTime,
+        time: formatDate(scheduledTime, 'H:m'),
         estimate:
-          liveEstimateTime === scheduledTime ? undefined : liveEstimateTime,
+          !liveEstimateTime || liveEstimateTime === scheduledTime
+            ? undefined
+            : formatDate(liveEstimateTime, 'H:m'),
       },
     )
 

--- a/site/src/components/timetable_row/hooks.tsx
+++ b/site/src/components/timetable_row/hooks.tsx
@@ -1,4 +1,3 @@
-import type React from 'react'
 import type { LocalizedStation } from '@junat/core/types'
 
 import { useRouter } from 'next/router'
@@ -60,16 +59,6 @@ export const useTimetableRowA11y = (props: UseTimetableRowA11yProps) => {
 
   return {
     ['aria-label']: getRowAriaLabel(),
-    role: 'button',
-    tabIndex: 0,
-    onKeyDown: (event: React.KeyboardEvent) => {
-      if (event.key === '\u0020' || event.key === 'Enter') {
-        event.preventDefault()
-        event.stopPropagation()
-
-        onRequestNavigate()
-      }
-    },
     onClick: onRequestNavigate,
   }
 }

--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -110,7 +110,7 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
         href={getTrainHref(t, train.departureDate, train.trainNumber)}
         className={cx(
           'grid w-full grid-cols-timetable-row gap-[0.5vw] no-underline focus-visible:outline',
-          'outline-secondary-400 outline-offset-8',
+          'outline-offset-8 outline-secondary-400',
         )}
         {...a11y}
         data-testid={TIMETABLE_ROW_TEST_ID}

--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -96,15 +96,9 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
   }
 
   return (
-    <motion.tr
-      {...a11y}
-      data-testid={TIMETABLE_ROW_TEST_ID}
-      ref={getPreviousStationAnimation({
-        lastStationId,
-        onCalculateAnimation: setBgAnimation,
-      })}
+    <motion.li
       className={cx(
-        'timetable-row-separator relative grid grid-cols-timetable-row gap-[0.5vw]',
+        'timetable-row-separator relative',
         'text-[0.88rem] [--tr-animation-from:theme(colors.primary.200)] first:pt-[5px]',
         '[border-bottom:1px_solid_theme(colors.gray.200)] dark:border-gray-800',
         'last:border-none dark:[--tr-animation-from:theme(colors.primary.800)]',
@@ -116,56 +110,66 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
       animate={['fadeIn', 'previous']}
       initial={{ opacity: fadeIn ? 0 : 1 }}
       variants={variants}
-      data-cancelled={train.cancelled}
-      title={train.cancelled ? t('cancelled') : undefined}
-      data-id={timetableRowId}
     >
-      <td className={tdStyle}>{targetStation?.stationName[locale]}</td>
-
-      <td className={tdStyle}>
-        {train.cancelled ? (
-          <span>{`(${scheduledTime}) ${t('cancelled')}`}</span>
-        ) : (
-          <div className="flex gap-[5px] [font-feature-settings:tnum]">
-            <time className={timeStyle} dateTime={row.scheduledTime}>
-              {scheduledTime}
-            </time>
-            {hasLiveEstimateTime && (
-              <time
-                dateTime={row.liveEstimateTime}
-                className={cx(
-                  timeStyle,
-                  'text-primary-700 dark:text-primary-400',
-                )}
-              >
-                {liveEstimateTime}
-              </time>
-            )}
-          </div>
-        )}
-      </td>
-      <td className={cx(tdStyle, 'flex justify-center')}>
-        {row.commercialTrack || '-'}
-      </td>
-      <td
-        className={cx(
-          tdStyle,
-          'flex justify-center',
-          hasLongTrainType && 'text-[min(2.5vw,80%)]',
-        )}
+      <button
+        className="grid w-full grid-cols-timetable-row gap-[0.5vw]"
+        {...a11y}
+        data-testid={TIMETABLE_ROW_TEST_ID}
+        ref={getPreviousStationAnimation({
+          lastStationId,
+          onCalculateAnimation: setBgAnimation,
+        })}
+        data-cancelled={train.cancelled}
+        title={train.cancelled ? t('cancelled') : undefined}
+        data-id={timetableRowId}
       >
-        <Link
-          /* The parent row is keyboard focusable and acts as a button */
-          tabIndex={-1}
-          aria-label={getTrainLabel(train, t)}
-          className="w-full cursor-default text-center"
-          href={getTrainHref(t, train.departureDate, train.trainNumber)}
-          onClick={() => setTimetableRowId(timetableRowId)}
+        <p className={tdStyle}>{targetStation?.stationName[locale]}</p>
+
+        <p className={tdStyle}>
+          {train.cancelled ? (
+            <span>{`(${scheduledTime}) ${t('cancelled')}`}</span>
+          ) : (
+            <div className="flex gap-[5px] [font-feature-settings:tnum]">
+              <time className={timeStyle} dateTime={row.scheduledTime}>
+                {scheduledTime}
+              </time>
+              {hasLiveEstimateTime && (
+                <time
+                  dateTime={row.liveEstimateTime}
+                  className={cx(
+                    timeStyle,
+                    'text-primary-700 dark:text-primary-400',
+                  )}
+                >
+                  {liveEstimateTime}
+                </time>
+              )}
+            </div>
+          )}
+        </p>
+        <p className={cx(tdStyle, 'flex justify-center')}>
+          {row.commercialTrack || '-'}
+        </p>
+        <p
+          className={cx(
+            tdStyle,
+            'flex justify-center',
+            hasLongTrainType && 'text-[min(2.5vw,80%)]',
+          )}
         >
-          {train.commuterLineID || `${train.trainType}${train.trainNumber}`}
-        </Link>
-      </td>
-    </motion.tr>
+          <Link
+            /* The parent row is keyboard focusable and acts as a button */
+            tabIndex={-1}
+            aria-label={getTrainLabel(train, t)}
+            className="w-full cursor-default text-center"
+            href={getTrainHref(t, train.departureDate, train.trainNumber)}
+            onClick={() => setTimetableRowId(timetableRowId)}
+          >
+            {train.commuterLineID || `${train.trainType}${train.trainNumber}`}
+          </Link>
+        </p>
+      </button>
+    </motion.li>
   )
 }
 

--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -86,6 +86,7 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
   const a11y = useTimetableRowA11y({
     train,
     targetStation,
+    track: row.commercialTrack,
     ...row,
   })
 

--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -129,7 +129,7 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
           {train.cancelled ? (
             <span>{`(${scheduledTime}) ${t('cancelled')}`}</span>
           ) : (
-            <div className="flex gap-[5px] [font-feature-settings:tnum]">
+            <span className="flex gap-[5px] [font-feature-settings:tnum]">
               <time className={timeStyle} dateTime={row.scheduledTime}>
                 {scheduledTime}
               </time>
@@ -144,7 +144,7 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
                   {liveEstimateTime}
                 </time>
               )}
-            </div>
+            </span>
           )}
         </p>
         <p className={cx(tdStyle, 'flex justify-center')}>

--- a/site/src/components/timetable_row/index.tsx
+++ b/site/src/components/timetable_row/index.tsx
@@ -17,10 +17,7 @@ import { useTimetableType } from '@junat/react-hooks'
 import { useStations } from '@junat/react-hooks/digitraffic/use_stations'
 import { useTimetableRow } from '@junat/react-hooks/use_timetable_row'
 
-import {
-  getPreviousStationAnimation,
-  getTrainLabel,
-} from '~/components/timetable_row/helpers'
+import { getPreviousStationAnimation } from '~/components/timetable_row/helpers'
 import { useTimetableRowA11y } from '~/components/timetable_row/hooks'
 import { translate, useLocale, useTranslations } from '~/i18n'
 
@@ -77,8 +74,6 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
   const hasLiveEstimateTime = getHasLiveEstimateTime(row)
   const hasLongTrainType = getHasLongTrainType(train)
 
-  const setTimetableRowId = useTimetableRow(state => state.setTimetableRowId)
-
   const targetStation = stations.find(
     station => station.stationShortCode === targetRow?.stationShortCode,
   )
@@ -100,19 +95,23 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
       className={cx(
         'timetable-row-separator relative',
         'text-[0.88rem] [--tr-animation-from:theme(colors.primary.200)] first:pt-[5px]',
-        '[border-bottom:1px_solid_theme(colors.gray.200)] dark:border-gray-800',
-        'last:border-none dark:[--tr-animation-from:theme(colors.primary.800)]',
+        'border-b-[1px] border-gray-200 last:border-none dark:border-gray-800',
+        'dark:[--tr-animation-from:theme(colors.primary.800)]',
         'dark:[--tr-animation-to:theme(colors.gray.900)] lg:text-[1rem]',
-        'py-[10px] [--tr-animation-to:theme(colors.gray.100)] focus-visible:ring-1',
-        'cursor-default dark:hover:bg-white/5 dark:focus-visible:ring-offset-transparent',
-        'hover:bg-white/50 focus-visible:ring-offset-1',
+        'py-[10px] [--tr-animation-to:theme(colors.gray.100)]',
+        'cursor-default dark:hover:bg-white/5',
+        'hover:bg-white/50',
       )}
       animate={['fadeIn', 'previous']}
       initial={{ opacity: fadeIn ? 0 : 1 }}
       variants={variants}
     >
-      <button
-        className="grid w-full grid-cols-timetable-row gap-[0.5vw]"
+      <Link
+        href={getTrainHref(t, train.departureDate, train.trainNumber)}
+        className={cx(
+          'grid w-full grid-cols-timetable-row gap-[0.5vw] no-underline focus-visible:outline',
+          'outline-secondary-400 outline-offset-8',
+        )}
         {...a11y}
         data-testid={TIMETABLE_ROW_TEST_ID}
         ref={getPreviousStationAnimation({
@@ -157,18 +156,11 @@ export function TimetableRow(props: Readonly<TimetableRowProps>) {
             hasLongTrainType && 'text-[min(2.5vw,80%)]',
           )}
         >
-          <Link
-            /* The parent row is keyboard focusable and acts as a button */
-            tabIndex={-1}
-            aria-label={getTrainLabel(train, t)}
-            className="w-full cursor-default text-center"
-            href={getTrainHref(t, train.departureDate, train.trainNumber)}
-            onClick={() => setTimetableRowId(timetableRowId)}
-          >
+          <span className="w-full cursor-default text-center">
             {train.commuterLineID || `${train.trainType}${train.trainNumber}`}
-          </Link>
+          </span>
         </p>
-      </button>
+      </Link>
     </motion.li>
   )
 }

--- a/site/src/features/pages/home/components/page.tsx
+++ b/site/src/features/pages/home/components/page.tsx
@@ -122,106 +122,110 @@ export function Home({ initialStations }: Readonly<HomeProps>) {
           siteName: SITE_NAME,
         })}
       />
-      <main onKeyDown={handleListNavigation}>
-        <h1 className="sr-only">{SITE_NAME}</h1>
+      <main>
+        <div onKeyDown={handleListNavigation} role="presentation">
+          <h1 className="sr-only">{SITE_NAME}</h1>
 
-        <SearchBar
-          ref={searchInputRef}
-          stations={stations}
-          locale={locale}
-          changeCallback={stations => {
-            setActiveStation(-1)
-            setStations(stations)
-            setShowFavorites(false)
-          }}
-          onSubmit={event => {
-            event.preventDefault()
+          <SearchBar
+            ref={searchInputRef}
+            stations={stations}
+            locale={locale}
+            changeCallback={stations => {
+              setActiveStation(-1)
+              setStations(stations)
+              setShowFavorites(false)
+            }}
+            onSubmit={event => {
+              event.preventDefault()
 
-            const activeOrFirst = Math.max(0, activeStation)
-            const path = getStationPath(
-              shownStations[activeOrFirst]!.stationName[locale],
-            )
+              const activeOrFirst = Math.max(0, activeStation)
+              const path = getStationPath(
+                shownStations[activeOrFirst]!.stationName[locale],
+              )
 
-            router.push(`/${router.locale}/${path}`)
-          }}
-          placeholder={t('searchForStation')}
-        />
-        <div style={{ marginBottom: '10px' }}>
-          <ToggleButton
-            aria-label={
-              showFavorites ? t('showAllStations') : t('showFavorites')
-            }
-            id="favorite"
-            onCheckedChange={setShowFavorites}
-            checked={showFavorites}
-          >
-            <List className="dark:fill-gray-300" />
-            <HeartFilled className="dark:fill-gray-300" />
-          </ToggleButton>
-        </div>
-        {showFavorites && favorites?.length === 0 && (
-          <Notification
-            title={t('emptyFavoritesHeading')}
-            body={t('emptyFavoritesBody')}
+              router.push(`/${router.locale}/${path}`)
+            }}
+            placeholder={t('searchForStation')}
           />
-        )}
-
-        <StationList
-          tabFocusable={showFavorites && favoriteStations.length > 0}
-          activeStation={activeStation}
-          stations={shownStations}
-        />
-
-        <GeolocationButton
-          translations={t('errors')}
-          label={t('buttons.geolocationLabel')}
-          locale={locale}
-          stations={initialStations}
-          onSuccess={setPosition}
-          onError={error => toast(error.localizedErrorMessage)}
-          onStations={stations => {
-            setOpen(true)
-            setNearbyStations(stations)
-          }}
-        />
-
-        <BottomSheet
-          initialFocusRef={false}
-          open={open}
-          snapPoints={({ minHeight }) => minHeight}
-          onDismiss={() => setOpen(false)}
-          header={<span>{t('nearbyStations')}</span>}
-          footer={
-            <span className="text-[10px] text-gray-600">
-              {position ? getLocalizedAccuracy({ locale, position, t }) : null}
-            </span>
-          }
-        >
-          <div
-            className={cx(
-              'flex max-h-48 snap-y snap-mandatory flex-col',
-              'items-start gap-[25px] overflow-y-scroll scroll-smooth px-[30px] py-5',
-            )}
-          >
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div
-                key={i}
-                className="flex w-full snap-center flex-col gap-2"
-                data-body-scroll-lock-ignore="true"
-              >
-                {nearbyStations.slice(i * 5, i * 5 + 5).map(station => (
-                  <Link
-                    className="w-full text-base no-underline"
-                    key={station.stationShortCode}
-                    href={getStationPath(station.stationName[locale])}
-                  >
-                    {station.stationName[locale]}
-                  </Link>
-                ))}
-              </div>
-            ))}
+          <div style={{ marginBottom: '10px' }}>
+            <ToggleButton
+              aria-label={
+                showFavorites ? t('showAllStations') : t('showFavorites')
+              }
+              id="favorite"
+              onCheckedChange={setShowFavorites}
+              checked={showFavorites}
+            >
+              <List className="dark:fill-gray-300" />
+              <HeartFilled className="dark:fill-gray-300" />
+            </ToggleButton>
           </div>
-        </BottomSheet>
+          {showFavorites && favorites?.length === 0 && (
+            <Notification
+              title={t('emptyFavoritesHeading')}
+              body={t('emptyFavoritesBody')}
+            />
+          )}
+
+          <StationList
+            tabFocusable={showFavorites && favoriteStations.length > 0}
+            activeStation={activeStation}
+            stations={shownStations}
+          />
+
+          <GeolocationButton
+            translations={t('errors')}
+            label={t('buttons.geolocationLabel')}
+            locale={locale}
+            stations={initialStations}
+            onSuccess={setPosition}
+            onError={error => toast(error.localizedErrorMessage)}
+            onStations={stations => {
+              setOpen(true)
+              setNearbyStations(stations)
+            }}
+          />
+
+          <BottomSheet
+            initialFocusRef={false}
+            open={open}
+            snapPoints={({ minHeight }) => minHeight}
+            onDismiss={() => setOpen(false)}
+            header={<span>{t('nearbyStations')}</span>}
+            footer={
+              <span className="text-[10px] text-gray-600">
+                {position
+                  ? getLocalizedAccuracy({ locale, position, t })
+                  : null}
+              </span>
+            }
+          >
+            <div
+              className={cx(
+                'flex max-h-48 snap-y snap-mandatory flex-col',
+                'items-start gap-[25px] overflow-y-scroll scroll-smooth px-[30px] py-5',
+              )}
+            >
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="flex w-full snap-center flex-col gap-2"
+                  data-body-scroll-lock-ignore="true"
+                >
+                  {nearbyStations.slice(i * 5, i * 5 + 5).map(station => (
+                    <Link
+                      className="w-full text-base no-underline"
+                      key={station.stationShortCode}
+                      href={getStationPath(station.stationName[locale])}
+                    >
+                      {station.stationName[locale]}
+                    </Link>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </BottomSheet>
+        </div>
       </main>
     </>
   )

--- a/site/src/features/pages/station/components/alert.tsx
+++ b/site/src/features/pages/station/components/alert.tsx
@@ -136,29 +136,16 @@ export const Alert = (props: { alert: AlertFragment }) => {
           : 'border-transparent',
       )}
     >
-      <section
-        tabIndex={0}
+      <button
         onClick={() => setOpen(!open)}
         onBlur={() => setHasFocus(false)}
         onFocusCapture={() => setHasFocus(true)}
-        onKeyDown={(event: React.KeyboardEvent<HTMLElement>) => {
-          if (
-            !(event.target instanceof HTMLElement) ||
-            !/section/i.test(event.target.tagName)
-          ) {
-            return
-          }
-
-          if (event.key === ' ' || event.key === 'Enter') {
-            event.preventDefault()
-            setOpen(!open)
-          }
-        }}
-        className="overflow-hidden text-sm leading-4"
+        aria-expanded={open}
+        className="overflow-hidden text-sm leading-4 text-left w-full"
       >
         <AlertHeader alert={alert} expanded={open} />
         <AlertContent visible={open} alert={alert} />
-      </section>
+      </button>
 
       <AlertCloseButton onClose={() => handleAlertHide(alert!)} />
     </motion.article>
@@ -177,6 +164,7 @@ const AlertHeader = ({
       <AnimatedChevron
         animate={{ rotate: expanded ? 0 : 180 }}
         className={cx('h-3 w-3 flex-shrink-0', ICON_FILL)}
+        aria-hidden="true"
       />
 
       <h5
@@ -220,6 +208,7 @@ const AlertContent = ({
               )}
               target="_blank"
               href={alert.alertUrl}
+              rel="noopener noreferrer"
             >
               {t('readMore')}
             </a>
@@ -242,8 +231,9 @@ const AlertCloseButton = ({
       className="ml-auto flex h-min rounded-full focus-visible:outline-offset-1"
       onClick={onClose}
       title={t('close')}
+      aria-label={t('close')}
     >
-      <Close className={ICON_FILL} />
+      <Close className={ICON_FILL} aria-hidden="true" />
     </button>
   )
 }

--- a/site/src/features/pages/station/components/weather_badge.tsx
+++ b/site/src/features/pages/station/components/weather_badge.tsx
@@ -56,6 +56,7 @@ export const WeatherBadge = (props: WeatherBadgeProps) => {
             </span>
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
+              alt={symbolTranslation}
               title={symbolTranslation}
               className="h-8 dark:brightness-150"
               src={`/weather_icons/${weather.data.SmartSymbol}.svg`}
@@ -78,6 +79,7 @@ export const WeatherBadge = (props: WeatherBadgeProps) => {
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
+                alt={symbolTranslation}
                 title={symbolTranslation}
                 className="h-8 dark:brightness-150"
                 src={`/weather_icons/${weather.data.SmartSymbol}.svg`}

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { MotionConfig } from 'motion/react'
 
 import 'core-js/actual/array/to-sorted'
 import '@junat/ui/bottom-sheet.css'
@@ -70,15 +71,17 @@ function AppProvider({ children }: Readonly<AppProviderProps>) {
   return (
     <QueryClientProvider client={queryClient}>
       <LocaleProvider locale={router.locale}>
-        <DialogProvider>
-          <ToastProvider>
-            {children}
-            <Toast />
-          </ToastProvider>
-        </DialogProvider>
-      </LocaleProvider>
+        <MotionConfig reducedMotion="user">
+          <DialogProvider>
+            <ToastProvider>
+              {children}
+              <Toast />
+            </ToastProvider>
+          </DialogProvider>
 
-      <ReactQueryDevtools buttonPosition="bottom-left" />
+          <ReactQueryDevtools buttonPosition="bottom-left" />
+        </MotionConfig>
+      </LocaleProvider>
     </QueryClientProvider>
   )
 }

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -48,7 +48,7 @@ a {
   cursor: pointer;
 }
 
-a:focus,
+a:focus-visible,
 a:hover {
   color: theme(colors.primary.600);
   transition: color 150ms cubic-bezier(0.075, 0.82, 0.165, 1);

--- a/tooling/eslint/next.js
+++ b/tooling/eslint/next.js
@@ -1,4 +1,5 @@
 import nextPlugin from '@next/eslint-plugin-next'
+import jsxA11y from 'eslint-plugin-jsx-a11y'
 import reactCompiler from 'eslint-plugin-react-compiler'
 
 /** @type {Awaited<import('typescript-eslint').Config>} */
@@ -8,8 +9,10 @@ export default [
     plugins: {
       '@next/next': nextPlugin,
       'react-compiler': reactCompiler,
+      'jsx-a11y': jsxA11y,
     },
     rules: {
+      ...jsxA11y.flatConfigs.recommended.rules,
       ...nextPlugin.configs.recommended.rules,
       ...nextPlugin.configs['core-web-vitals'].rules,
       // TypeError: context.getAncestors is not a function

--- a/tooling/eslint/package.json
+++ b/tooling/eslint/package.json
@@ -16,6 +16,7 @@
     "@stylistic/eslint-plugin": "^4.2.0",
     "eslint": "^9.23.0",
     "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-compiler": "19.0.0-beta-e993439-20250328",
     "eslint-plugin-sonarjs": "^3.0.2",
     "eslint-plugin-unicorn": "^58.0.0",


### PR DESCRIPTION
-   In `TrainsFilterDialog`, the `onOpenAutoFocus` event handler now includes a `requestAnimationFrame` call to ensure the input field receives focus correctly, especially on iOS Safari. This prevents layout issues when the virtual keyboard appears.
-   In `TimetableTypeRadio`, the visual separator "-->" has been replaced with right-arrow character ("\u2192"). The spacing around the arrow has also been adjusted for better readability (iOS).
- fix: improve accessibility and focus handling in filter dialog
- feat: Improve timetable row display and accessibility
- fix: Improve focus style for links
- fix: remove unnecessary `role="option"` from station list item
- feat: improve timetable and timetable row
- feat: use motion/react reduced motion support
- fix: improve timetable row time display
- feat: improve timetable row navigation and accessibility
- fix: improve accessibility in timetable components
- feat: enhance accessibility and add eslint rules
