### PR TITLE
fix: polyfill url parse

### DIFF
--- a/site/src/features/pages/settings/components/home_list_togle.tsx
+++ b/site/src/features/pages/settings/components/home_list_togle.tsx
@@ -9,7 +9,7 @@ export const HomeListToggle = () => {
   const [isDefault, setIsDefault] = useFavorites(store => [
     store.homePageDefaultList,
     store.setHomePageDefaultList,
-  ])
+])
 
   const t = useTranslations()
 

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { MotionConfig } from 'motion/react'
 
 import 'core-js/actual/array/to-sorted'
+import 'core-js/actual/url/parse'
 import '@junat/ui/bottom-sheet.css'
 
 import { useWakeLock } from '@junat/react-hooks/use_wake_lock'


### PR DESCRIPTION
Affects opening an alert on station page (alert.tsx@hasAlertUrl). URL.parse is baseline, but has poor support for older browsers (esp. Safari)

Fixes JUNAT-AP
